### PR TITLE
Chapter/9 parsing

### DIFF
--- a/src/SimpleDb/Parsing/Clauses.cs
+++ b/src/SimpleDb/Parsing/Clauses.cs
@@ -1,6 +1,6 @@
 ﻿namespace SimpleDb.Parsing
 {
-    public record class FromClause(SyntaxToken FromKeyword, QuerySource Source);
+    public record class FromClause(SyntaxToken FromKeyword, SyntaxNode Source);
 
     public record class WhereClause(SyntaxToken WhereKeyword, Expression Condition);
 }

--- a/src/SimpleDb/Parsing/Clauses.cs
+++ b/src/SimpleDb/Parsing/Clauses.cs
@@ -1,0 +1,6 @@
+﻿namespace SimpleDb.Parsing
+{
+    public record class FromClause(SyntaxToken FromKeyword, QuerySource Source);
+
+    public record class WhereClause(SyntaxToken WhereKeyword, Expression Condition);
+}

--- a/src/SimpleDb/Parsing/DeleteStatement.cs
+++ b/src/SimpleDb/Parsing/DeleteStatement.cs
@@ -1,0 +1,7 @@
+﻿namespace SimpleDb.Parsing
+{
+    public record class DeleteStatement : Statement
+    {
+        public override SyntaxKind Kind => SyntaxKind.DeleteStatement;
+    }
+}

--- a/src/SimpleDb/Parsing/Expression.cs
+++ b/src/SimpleDb/Parsing/Expression.cs
@@ -41,14 +41,20 @@
     }
 
     public record class MemberAccessExpression(
+        SyntaxToken? Object,
+        SyntaxToken? DotToken,
         SyntaxToken Member) : Expression
     {
+        public MemberAccessExpression(SyntaxToken Member) : this(null, null, Member)
+        {
+        }
+        public bool IsQualified => Object != null;
         public override SyntaxKind Kind => SyntaxKind.MemberAccess;
     }
 
     public record class AliasExpression(
         Expression Expression,
-        SyntaxToken AsToken,
+        SyntaxToken? AsToken,
         SyntaxToken Alias) : Expression
     {
         public override SyntaxKind Kind => SyntaxKind.Alias;

--- a/src/SimpleDb/Parsing/Expression.cs
+++ b/src/SimpleDb/Parsing/Expression.cs
@@ -1,0 +1,73 @@
+﻿namespace SimpleDb.Parsing
+{
+    public abstract record class Expression : SyntaxNode
+    {
+
+    }
+
+
+    public record class StarExpression(SyntaxToken StarToken) : Expression
+    {
+        public override SyntaxKind Kind => SyntaxKind.Star;
+    }
+
+    public record class UnaryExpression(
+        SyntaxToken OperatorToken,
+        Expression Operand) : Expression
+    {
+        public override SyntaxKind Kind => SyntaxKind.Unary;
+    }
+
+    public record class LiteralExpression(
+        SyntaxToken LiteralToken) : Expression
+    {
+        public override SyntaxKind Kind => SyntaxKind.Literal;
+    }
+
+    public record class AssignmentExpression(
+        SyntaxToken Identifier,
+        SyntaxToken EqualToken,
+        Expression Value) : Expression
+    {
+        public override SyntaxKind Kind => SyntaxKind.Assignment;
+    }
+
+    public record class BinaryExpression(
+        Expression Left,
+        SyntaxToken OperatorToken,
+        Expression Right) : Expression
+    {
+        public override SyntaxKind Kind => SyntaxKind.Binary;
+    }
+
+    public record class MemberAccessExpression(
+        SyntaxToken Member) : Expression
+    {
+        public override SyntaxKind Kind => SyntaxKind.MemberAccess;
+    }
+
+    public record class AliasExpression(
+        Expression Expression,
+        SyntaxToken AsToken,
+        SyntaxToken Alias) : Expression
+    {
+        public override SyntaxKind Kind => SyntaxKind.Alias;
+    }
+
+    public record class ParenthesizedExpression(
+        SyntaxToken LeftParen,
+        Expression InnerExpression,
+        SyntaxToken RightParen) : Expression
+    {
+        public override SyntaxKind Kind => SyntaxKind.ParenthesizedExpr;
+    }
+
+    public record class MethodCallExpression(
+        SyntaxToken MethodName,
+        SyntaxToken LeftParen,
+        List<Expression> Arguments,
+        SyntaxToken RightParen) : Expression
+    {
+        public override SyntaxKind Kind => SyntaxKind.MethodCall;
+    }
+}

--- a/src/SimpleDb/Parsing/Parser.cs
+++ b/src/SimpleDb/Parsing/Parser.cs
@@ -1,4 +1,6 @@
-﻿namespace SimpleDb.Parsing
+﻿using SimpleDb.Metadata;
+
+namespace SimpleDb.Parsing
 {
     public partial class Parser(List<SyntaxToken> tokens)
     {
@@ -41,6 +43,11 @@
                 throw new Exception("Expected at least one column in SELECT statement.");
             }
 
+            if (Current.Type == TokenType.EOF)
+            {
+                return new SelectStatement(select, columns, null, null);
+            }
+
             FromClause fromExpr = FromClause();
             WhereClause? whereExpr = null;
             if(Current.Type == TokenType.Where)
@@ -64,23 +71,74 @@
         private FromClause FromClause()
         {
             SyntaxToken fromToken = Match(TokenType.From); // Consume 'FROM'
-            SubQuery? nestedQuery = null;
-            SyntaxToken? tableOrViewName = null;
-            MethodCallExpression? methodCall = null;
+            Expression src = Join();
+
+            return new FromClause(fromToken, src);
+        }
+
+        private Expression Join()
+        {
+            Expression src = QuerySource();
+            do
+            {
+                JoinType? type = null;
+                if(Current.Type == TokenType.Comma)
+                {
+                    //select a, b from tb1, tb2 on tb1.a = tb2.k
+                    Advance();
+                    type = JoinType.Inner;
+                }
+                else if(Current.Type == TokenType.Join)
+                {
+                    //tb1 join tb2
+                    Advance(); //consume join
+                    type = JoinType.Inner;
+                }
+                else if (Current.Type == TokenType.Inner)
+                {
+                    //tb1 inner join tbl2
+                    Advance(); //consume inner
+                    Match(TokenType.Join); //consume join
+                    type = JoinType.Inner;
+                }
+                else if (Current.Type == TokenType.Outer)
+                {
+                    //tbl outer join tbl2
+                    Advance();
+                    Match(TokenType.Join);
+                    type = JoinType.Outer;
+                }
+
+                if(!type.HasValue)
+                {
+                    break;
+                }
+                Expression right = QuerySource();
+                Match(TokenType.On);
+                Expression condition = Expression();
+                src = new JoinExpression(type.Value, src, right, condition);
+            }
+            while (true);
+            return src;
+        }
+
+        private Expression QuerySource()
+        {
+            Expression source;
 
             switch (Current.Type)
             {
                 case TokenType.LeftParen:
-                    nestedQuery = SubQuery();
+                    source = SubQuery();
                     break;
                 case TokenType.Identifier:
                     if (Peek(1).Type == TokenType.LeftParen)
                     {
-                        methodCall = MethodCallExpression();
+                        source = MethodCallExpression();
                     }
                     else
                     {
-                        tableOrViewName = Match(TokenType.Identifier);
+                        source = MemberAccess();
                     }
                     break;
                 default:
@@ -89,10 +147,11 @@
             }
 
             SyntaxToken? alias = null;
+            SyntaxToken? asToken = null;
 
             if (Current.Type == TokenType.As)
             {
-                Advance(); // Consume 'AS'
+                asToken = Advance(); // Consume 'AS'
                 alias = Match(TokenType.Identifier);
             }
             else if (Current.Type == TokenType.Identifier)
@@ -100,9 +159,12 @@
                 alias = Advance(); // Consume alias
             }
 
-            QuerySource source = QuerySource.FromOne(tableOrViewName, nestedQuery, methodCall, alias);
 
-            return new FromClause(fromToken, source);
+            if (alias is not null)
+                return new AliasExpression(source, asToken, alias);
+
+            return source;
+                
         }
 
         private WhereClause WhereClause()
@@ -217,12 +279,14 @@
                         // It's a method call
                         return MethodCallExpression();
                     }
-                    SyntaxToken identifierToken = Advance(); // Consume identifier
-                    return new MemberAccessExpression(identifierToken);
+                    else
+                    {
+                        return MemberAccess();
+                    }
                 case TokenType.LeftParen:
                     return ParenthesizedExpression();
                 case TokenType.Star:
-                    SyntaxToken starToken = Advance(); // Consume '*'
+                    SyntaxToken starToken = Advance(); // Consume '*' in select * from
                     return new StarExpression(starToken);
                 default:
                     throw new Exception($"Unexpected token: {Current.Type}");
@@ -267,6 +331,22 @@
             }
             SyntaxToken rightParen = Match(TokenType.RightParen); // Consume ')'
             return new MethodCallExpression(methodName, leftParen, arguments, rightParen);
+        }
+
+        private MemberAccessExpression MemberAccess()
+        {
+            SyntaxToken identifierToken = Advance(); // Consume identifier
+            if (Current.Type == TokenType.Dot)
+            {
+                SyntaxToken dot = Advance();
+                // Consume identifier
+                SyntaxToken qualifiedIdentifier = Match(TokenType.Identifier);
+                return new MemberAccessExpression(identifierToken, dot, qualifiedIdentifier);
+            }
+            else
+            {
+                return new MemberAccessExpression(identifierToken);
+            }
         }
 
         public SyntaxToken Advance()

--- a/src/SimpleDb/Parsing/Parser.cs
+++ b/src/SimpleDb/Parsing/Parser.cs
@@ -217,7 +217,7 @@ namespace SimpleDb.Parsing
         Expression Equal()
         {
             Expression left = Term();
-            while (Current.Type == TokenType.Equal || Current.Type == TokenType.BangEqual
+            if (Current.Type == TokenType.Equal || Current.Type == TokenType.BangEqual
                 || Current.Type == TokenType.LessThan || Current.Type == TokenType.LessThanEqual
                 || Current.Type == TokenType.GreaterThan || Current.Type == TokenType.GreaterThanEqual)
             {

--- a/src/SimpleDb/Parsing/Parser.cs
+++ b/src/SimpleDb/Parsing/Parser.cs
@@ -15,6 +15,7 @@
                 TokenType.Update => ParseUpdateStatement(),
                 TokenType.Delete => ParseDeleteStatement(),
                 TokenType.EOF => throw new Exception("Unexpected end of input."),
+                _ => throw new Exception($"Unexpected token: [{Current.Type}] '{Current.Lexeme}' as start of sql statement")
             };
         }
 
@@ -34,6 +35,10 @@
                     // No more columns to parse
                     break;
                 }
+            }
+            if(columns.Count == 0)
+            {
+                throw new Exception("Expected at least one column in SELECT statement.");
             }
 
             FromClause fromExpr = FromClause();

--- a/src/SimpleDb/Parsing/Parser.cs
+++ b/src/SimpleDb/Parsing/Parser.cs
@@ -1,0 +1,292 @@
+﻿namespace SimpleDb.Parsing
+{
+    public partial class Parser(List<SyntaxToken> tokens)
+    {
+        private int _current = 0;
+        private SyntaxToken Current => Peek(0);
+
+        public bool IsAtEnd() => Current.Type == TokenType.EOF;
+
+        public Statement Parse()
+        {
+            return Current.Type switch
+            {
+                TokenType.Select => ParseSelectStatement(),
+                TokenType.Update => ParseUpdateStatement(),
+                TokenType.Delete => ParseDeleteStatement(),
+                TokenType.EOF => throw new Exception("Unexpected end of input."),
+            };
+        }
+
+        private SelectStatement ParseSelectStatement()
+        {
+            SyntaxToken select = Match(TokenType.Select); // Consume 'SELECT'
+            List<Expression> columns = [];
+            while (!IsAtEnd())
+            {
+                columns.Add(Expression());
+                if (Current.Type == TokenType.Comma)
+                {
+                    Advance(); // Consume ','
+                }
+                else
+                {
+                    // No more columns to parse
+                    break;
+                }
+            }
+
+            FromClause fromExpr = FromClause();
+            WhereClause? whereExpr = null;
+            if(Current.Type == TokenType.Where)
+            {
+                whereExpr = WhereClause();
+            }
+
+            return new SelectStatement(select, columns, fromExpr, whereExpr);
+        }
+
+        private UpdateStatement ParseUpdateStatement()
+        {
+            throw new NotImplementedException();
+        }
+
+        private DeleteStatement ParseDeleteStatement()
+        {
+            throw new NotImplementedException();
+        }
+
+        private FromClause FromClause()
+        {
+            SyntaxToken fromToken = Match(TokenType.From); // Consume 'FROM'
+            SubQuery? nestedQuery = null;
+            SyntaxToken? tableOrViewName = null;
+            MethodCallExpression? methodCall = null;
+
+            switch (Current.Type)
+            {
+                case TokenType.LeftParen:
+                    nestedQuery = SubQuery();
+                    break;
+                case TokenType.Identifier:
+                    if (Peek(1).Type == TokenType.LeftParen)
+                    {
+                        methodCall = MethodCallExpression();
+                    }
+                    else
+                    {
+                        tableOrViewName = Match(TokenType.Identifier);
+                    }
+                    break;
+                default:
+                    throw new Exception("Unexpected token in FROM clause. " + Current.Type);
+
+            }
+
+            SyntaxToken? alias = null;
+
+            if (Current.Type == TokenType.As)
+            {
+                Advance(); // Consume 'AS'
+                alias = Match(TokenType.Identifier);
+            }
+            else if (Current.Type == TokenType.Identifier)
+            {
+                alias = Advance(); // Consume alias
+            }
+
+            QuerySource source = QuerySource.FromOne(tableOrViewName, nestedQuery, methodCall, alias);
+
+            return new FromClause(fromToken, source);
+        }
+
+        private WhereClause WhereClause()
+        {
+            SyntaxToken whereToken = Advance(); // Consume 'WHERE'
+            Expression condition = Or();
+            return new WhereClause(whereToken, condition);
+        }
+        private Expression Expression()
+        {
+            return Alias();
+        }
+
+        Expression Alias()
+        {
+            Expression expr = Or();
+            if(Current.Type == TokenType.As)
+            {
+                SyntaxToken asToken = Advance(); // Consume 'AS'
+                SyntaxToken aliasToken = Match(TokenType.Identifier); // Consume identifier
+                expr = new AliasExpression(expr, asToken, aliasToken);
+            }
+            return expr;
+        }
+
+        Expression Or()
+        {
+            Expression left = And();
+            while (Current.Type == TokenType.Or)
+            {
+                SyntaxToken operatorToken = Advance(); // Consume 'OR'
+                Expression right = And();
+                left = new BinaryExpression(left, operatorToken, right);
+            }
+            return left;
+        }
+
+        Expression And()
+        {
+            Expression left = Equal();
+            while (Current.Type == TokenType.And)
+            {
+                SyntaxToken operatorToken = Advance(); // Consume 'AND'
+                Expression right = Equal();
+                left = new BinaryExpression(left, operatorToken, right);
+            }
+            return left;
+        }
+
+        Expression Equal()
+        {
+            Expression left = Term();
+            while (Current.Type == TokenType.Equal || Current.Type == TokenType.BangEqual
+                || Current.Type == TokenType.LessThan || Current.Type == TokenType.LessThanEqual
+                || Current.Type == TokenType.GreaterThan || Current.Type == TokenType.GreaterThanEqual)
+            {
+                SyntaxToken operatorToken = Advance();
+                Expression right = Term();
+                left = new BinaryExpression(left, operatorToken, right);
+            }
+            return left;
+        }
+
+        Expression Term()
+        {
+            Expression left = Factor();
+            while (Current.Type == TokenType.Plus || Current.Type == TokenType.Minus)
+            {
+                SyntaxToken operatorToken = Advance(); // Consume '+' or '-'
+                Expression right = Factor();
+                left = new BinaryExpression(left, operatorToken, right);
+            }
+            return left;
+        }
+
+        Expression Factor()
+        {
+            Expression left = Unary();
+            while (Current.Type == TokenType.Star || Current.Type == TokenType.ForwardSlash || Current.Type == TokenType.Percent)
+            {
+                SyntaxToken operatorToken = Advance(); // Consume '*' or '/'
+                Expression right = Unary();
+                left = new BinaryExpression(left, operatorToken, right);
+            }
+            return left;
+        }
+
+        Expression Unary()
+        {
+            if(Current.Type == TokenType.Minus || Current.Type == TokenType.Bang)
+            {
+                SyntaxToken operatorToken = Advance(); // Consume '-' or 'NOT'
+                Expression right = Primary();
+                return new UnaryExpression(operatorToken, right);
+            }
+            return Primary();
+        }
+
+        Expression Primary()
+        {
+            switch(Current.Type)
+            {
+                case TokenType.IntValue:
+                    SyntaxToken numberToken = Advance(); // Consume number
+                    return new LiteralExpression(numberToken);
+                case TokenType.StringValue:
+                    SyntaxToken stringToken = Advance(); // Consume string
+                    return new LiteralExpression(stringToken);
+                case TokenType.Identifier:
+                    if(Peek(1).Type == TokenType.LeftParen)
+                    {
+                        // It's a method call
+                        return MethodCallExpression();
+                    }
+                    SyntaxToken identifierToken = Advance(); // Consume identifier
+                    return new MemberAccessExpression(identifierToken);
+                case TokenType.LeftParen:
+                    return ParenthesizedExpression();
+                case TokenType.Star:
+                    SyntaxToken starToken = Advance(); // Consume '*'
+                    return new StarExpression(starToken);
+                default:
+                    throw new Exception($"Unexpected token: {Current.Type}");
+            }
+        }
+
+        private SubQuery SubQuery()
+        {
+            SyntaxToken leftParen = Match(TokenType.LeftParen); // Consume '('
+            SelectStatement expr = ParseSelectStatement();
+            SyntaxToken rightParen = Match(TokenType.RightParen); // Consume ')'
+            return new SubQuery(leftParen,expr, rightParen);
+        }
+
+        private ParenthesizedExpression ParenthesizedExpression()
+        {
+            SyntaxToken leftParen = Match(TokenType.LeftParen); // Consume '('
+            Expression expr = Expression();
+            SyntaxToken rightParen = Match(TokenType.RightParen); // Consume ')'
+            return new ParenthesizedExpression(leftParen, expr, rightParen);
+        }
+
+        private MethodCallExpression MethodCallExpression()
+        {
+            SyntaxToken methodName = Match(TokenType.Identifier); // Consume method name
+            SyntaxToken leftParen = Match(TokenType.LeftParen); // Consume '('
+            List<Expression> arguments = [];
+            if (Current.Type != TokenType.RightParen)
+            {
+                do
+                {
+                    arguments.Add(Expression());
+                    if (Current.Type == TokenType.Comma)
+                    {
+                        Advance(); // Consume ','
+                    }
+                    else
+                    {
+                        break;
+                    }
+                } while (true);
+            }
+            SyntaxToken rightParen = Match(TokenType.RightParen); // Consume ')'
+            return new MethodCallExpression(methodName, leftParen, arguments, rightParen);
+        }
+
+        public SyntaxToken Advance()
+        {
+            SyntaxToken token = Current;
+            if (!IsAtEnd())
+                _current++;
+            return token;
+        }
+
+        private SyntaxToken Peek(int offset)
+        {
+            int index = _current + offset;
+            if (index >= tokens.Count)
+                return tokens[^1];
+            return tokens[index];
+        }
+
+        private SyntaxToken Match(TokenType expectedType)
+        {
+            if (Current.Type != expectedType)
+                throw new Exception($"Expected token of type {expectedType}, but found {Current.Type}.");
+            return Advance();
+        }
+
+
+    }
+}

--- a/src/SimpleDb/Parsing/Scanner.cs
+++ b/src/SimpleDb/Parsing/Scanner.cs
@@ -1,0 +1,202 @@
+﻿using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace SimpleDb.Parsing
+{
+    public class Scanner(string queryText)
+    {
+        private static readonly Dictionary<string, TokenType> _keywords = new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["select"] = TokenType.Select,
+            ["update"] = TokenType.Update,
+            ["delete"] = TokenType.Delete,
+            ["from"] = TokenType.From,
+            ["as"] = TokenType.AS,
+            ["and"] = TokenType.And,
+            ["or"] = TokenType.Or
+        };
+
+        private int _pos = 0, _start = 0;
+        private List<SyntaxToken> _tokens = [];
+
+        private bool IsAtEnd => _pos >= queryText.Length;
+
+        private char Current => IsAtEnd ? '\0' : queryText[_pos];
+
+        public List<SyntaxError> SyntaxErrors { get; } = [];
+
+        public List<SyntaxToken> GetTokens()
+        {
+            //Our query can start with
+            //select, update and delete
+            while (!IsAtEnd)
+            {
+                _start = _pos;
+                char c = Advance();
+                switch(c)
+                {
+                    case '(':
+                        AddToken(TokenType.LeftParen, null);
+                        break;
+                    case ')':
+                        AddToken(TokenType.RightParen, null);
+                        break;
+                    case '+':
+                        AddToken(TokenType.Plus, null);
+                        break;
+                    case '-': 
+                        AddToken(TokenType.Minus, null);
+                        break;
+                    case '*':
+                        AddToken(TokenType.Star, null);
+                        break;
+                    case '/':
+                        AddToken(TokenType.ForwardSlash, null);
+                        break;
+                    case '%':
+                        AddToken(TokenType.Percent, null);
+                        break;
+                    case '!':
+                        AddToken(Match('=') ? TokenType.BangEqual : TokenType.Bang, null);
+                        break;
+                    case '=':
+                        AddToken(TokenType.Equal, null);
+                        break;
+                    case '<':
+                        AddToken(Match('=') ? TokenType.LessThanEqual : TokenType.LessThan, null);
+                        break;
+                    case '>':
+                        AddToken(Match('=') ? TokenType.GreaterThanEqual : TokenType.GreaterThan, null);
+                        break;
+                    case '\'':
+                        AddString();
+                        break;
+                    case '0':
+                    case '1':
+                    case '2':
+                    case '3':
+                    case '4':
+                    case '5':
+                    case '6':
+                    case '7':
+                    case '8':
+                    case '9':
+                        AddNumber();
+                        break;
+                    case '\r':
+                    case ' ':
+                    case '\t':
+                        break;
+                    default:
+                        {
+                            if (char.IsLetter(c))
+                            {
+                                AddIdentifierOrKeyword();
+                            }
+                            else
+                            {
+                                Error($"Unexpected char: '{c}'.");
+                            }
+                            break;
+                        }
+                }
+                
+            }
+
+            return _tokens;
+        }
+
+       
+        private char Peek()
+        {
+            int p = _pos + 1;
+            if(p < queryText.Length) 
+                return queryText[p];
+            return '\0';
+        }
+
+        private char Peek(int count)
+        {
+            int p = _pos + count;
+            if(count < queryText.Length)
+                return queryText[p];
+            return '\0';
+        }
+
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private char Advance()
+        {
+            char c = queryText[_pos];
+            _pos++;
+            return c;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void AddToken(TokenType tokenType, object? literal)
+        {
+            var lexeme = queryText[_start.._pos];
+            _tokens.Add(new SyntaxToken(tokenType, lexeme, _start, literal));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private bool Match(char c)
+        {
+            if (Current == c)
+            {
+                _pos ++;
+                return true;
+            }
+            return false;
+        }
+
+        private void AddNumber()
+        {
+            while (char.IsDigit(Current))
+                Advance();
+            //_pos is now at the first non digit char
+            //so the number is from _start to _pos-1
+            if (int.TryParse(queryText.AsSpan(_start, _pos - _start), null, out int v))
+                AddToken(TokenType.IntValue, v);
+            Error($"Unable to parse number");
+        }
+
+        private void AddString()
+        {
+            StringBuilder sb = new StringBuilder();
+            while (!IsAtEnd)
+            {
+                char c = Advance();
+                if(c == '\'')
+                {
+                    if (Current == '\'') //Handle ''. The previous quote is escaped.
+                    {
+                        sb.Append('\''); //we escape quote ' by writing as double quote ''
+                        Advance();
+                    }
+                    else
+                        break;
+                }
+                else
+                {
+                    sb.Append(c);
+                }
+            }
+            AddToken(TokenType.StringValue, sb.ToString());
+        }
+
+        private void AddIdentifierOrKeyword()
+        {
+            while(char.IsLetterOrDigit(Current))
+            {
+                Advance();
+            }
+            string text = queryText[_start.._pos];
+            TokenType tokenType = _keywords.TryGetValue(text, out var type) ? type : TokenType.Identifier;
+            AddToken(tokenType, text);
+        }
+
+        private void Error(string message)
+            => SyntaxErrors.Add(new Parsing.SyntaxError(message, _start));
+    }
+}

--- a/src/SimpleDb/Parsing/Scanner.cs
+++ b/src/SimpleDb/Parsing/Scanner.cs
@@ -18,7 +18,7 @@ namespace SimpleDb.Parsing
         };
 
         private int _pos = 0, _start = 0;
-        private List<SyntaxToken> _tokens = [];
+        private readonly List<SyntaxToken> _tokens = [];
 
         private bool IsAtEnd => _pos >= queryText.Length;
 
@@ -121,7 +121,7 @@ namespace SimpleDb.Parsing
         private char Peek(int count)
         {
             int p = _pos + count;
-            if(count < queryText.Length)
+            if(p < queryText.Length)
                 return queryText[p];
             return '\0';
         }
@@ -160,8 +160,12 @@ namespace SimpleDb.Parsing
             //_pos is now at the first non digit char
             //so the number is from _start to _pos-1
             if (int.TryParse(queryText.AsSpan(_start, _pos - _start), null, out int v))
+            {
                 AddToken(TokenType.IntValue, v);
-            Error($"Unable to parse number");
+            }
+            {
+                Error($"Unable to parse number");
+            }
         }
 
         private void AddString()

--- a/src/SimpleDb/Parsing/Scanner.cs
+++ b/src/SimpleDb/Parsing/Scanner.cs
@@ -11,7 +11,8 @@ namespace SimpleDb.Parsing
             ["update"] = TokenType.Update,
             ["delete"] = TokenType.Delete,
             ["from"] = TokenType.From,
-            ["as"] = TokenType.AS,
+            ["where"] = TokenType.Where,
+            ["as"] = TokenType.As,
             ["and"] = TokenType.And,
             ["or"] = TokenType.Or
         };

--- a/src/SimpleDb/Parsing/Scanner.cs
+++ b/src/SimpleDb/Parsing/Scanner.cs
@@ -72,6 +72,9 @@ namespace SimpleDb.Parsing
                     case '\'':
                         AddString();
                         break;
+                    case ',':
+                        AddToken(TokenType.Comma, null);
+                        break; 
                     case '0':
                     case '1':
                     case '2':
@@ -87,6 +90,7 @@ namespace SimpleDb.Parsing
                     case '\r':
                     case ' ':
                     case '\t':
+                    case '\n':
                         break;
                     default:
                         {
@@ -194,7 +198,7 @@ namespace SimpleDb.Parsing
 
         private void AddIdentifierOrKeyword()
         {
-            while(char.IsLetterOrDigit(Current))
+            while(char.IsLetterOrDigit(Current) || Current == '_')
             {
                 Advance();
             }

--- a/src/SimpleDb/Parsing/Scanner.cs
+++ b/src/SimpleDb/Parsing/Scanner.cs
@@ -14,7 +14,12 @@ namespace SimpleDb.Parsing
             ["where"] = TokenType.Where,
             ["as"] = TokenType.As,
             ["and"] = TokenType.And,
-            ["or"] = TokenType.Or
+            ["or"] = TokenType.Or,
+            ["join"] = TokenType.Join,
+            ["on"] = TokenType.On,
+            ["inner"] = TokenType.Inner,
+            ["outer"] = TokenType.Outer,
+            ["cross"] = TokenType.Cross
         };
 
         private int _pos = 0, _start = 0;
@@ -75,6 +80,9 @@ namespace SimpleDb.Parsing
                     case ',':
                         AddToken(TokenType.Comma, null);
                         break; 
+                    case '.':
+                        AddToken(TokenType.Dot, null);
+                        break;
                     case '0':
                     case '1':
                     case '2':

--- a/src/SimpleDb/Parsing/Scanner.cs
+++ b/src/SimpleDb/Parsing/Scanner.cs
@@ -103,6 +103,8 @@ namespace SimpleDb.Parsing
                 
             }
 
+            _tokens.Add(new SyntaxToken(TokenType.EOF, string.Empty, _pos, null));
+
             return _tokens;
         }
 

--- a/src/SimpleDb/Parsing/SelectStatement.cs
+++ b/src/SimpleDb/Parsing/SelectStatement.cs
@@ -1,0 +1,19 @@
+﻿namespace SimpleDb.Parsing
+{
+    public record class SelectStatement(
+        SyntaxToken SelectKeyword,
+        List<Expression> Values, 
+        FromClause From,
+        WhereClause? Where) : Statement
+    {
+        public override SyntaxKind Kind => SyntaxKind.SelectStatement;
+    }
+
+    public record class SubQuery(
+        SyntaxToken LeftParen,
+        SelectStatement Query,
+        SyntaxToken RightParen) : Statement
+    {
+        public override SyntaxKind Kind => SyntaxKind.SubQuery;
+    }
+}

--- a/src/SimpleDb/Parsing/SelectStatement.cs
+++ b/src/SimpleDb/Parsing/SelectStatement.cs
@@ -3,7 +3,7 @@
     public record class SelectStatement(
         SyntaxToken SelectKeyword,
         List<Expression> Values, 
-        FromClause From,
+        FromClause? From,
         WhereClause? Where) : Statement
     {
         public override SyntaxKind Kind => SyntaxKind.SelectStatement;
@@ -12,7 +12,7 @@
     public record class SubQuery(
         SyntaxToken LeftParen,
         SelectStatement Query,
-        SyntaxToken RightParen) : Statement
+        SyntaxToken RightParen) : Expression
     {
         public override SyntaxKind Kind => SyntaxKind.SubQuery;
     }

--- a/src/SimpleDb/Parsing/Statement.cs
+++ b/src/SimpleDb/Parsing/Statement.cs
@@ -1,0 +1,88 @@
+﻿namespace SimpleDb.Parsing
+{
+    public enum SyntaxKind
+    {
+        //select
+        Select,
+        Update,
+        Delete,
+        Literal,
+        Binary,
+        Where,
+        From,
+
+        //statements
+        SelectStatement,
+        UpdateStatement,
+        DeleteStatement,
+        SubQuery,
+
+        //expresions
+        Star,
+        Unary,
+        ParenthesizedExpr,
+        Assignment,
+        MemberAccess,
+        Alias,
+        MethodCall,
+
+        //table source
+        QuerySource
+    }
+    public abstract record class SyntaxNode
+    {
+        public abstract SyntaxKind Kind { get; }
+    }
+    public abstract record class Statement : SyntaxNode
+    {
+    }
+
+    public record class QuerySource : Statement
+    {
+        public const int TableOrView = 0, SubQuery = 1, TVF = 2;
+
+        override public SyntaxKind Kind => SyntaxKind.QuerySource;
+        public QuerySource(SyntaxToken tableOrViewName, SyntaxToken? alias)
+        {
+            TableOrViewName = tableOrViewName;
+            Alias = alias;
+        }
+
+        public QuerySource(MethodCallExpression tvf, SyntaxToken? alias)
+        {
+            TableValuedFunction = tvf;
+            Alias = alias;
+            SubType = TVF;
+        }
+
+        public QuerySource(SubQuery nestedQuery, SyntaxToken? alias)
+        {
+            NestedQuery = nestedQuery;
+            Alias = alias;
+            SubType = SubQuery;
+        }
+
+        public SyntaxToken? TableOrViewName { get; }
+
+        public MethodCallExpression? TableValuedFunction { get; }
+
+        public SubQuery? NestedQuery { get; }
+
+        public SyntaxToken? Alias { get; }
+
+        public int SubType { get; } // 0=TableOrView, 1=SubQuery, 2=TVF
+
+        public static QuerySource FromOne(SyntaxToken? tableOrViewName, SubQuery? subQuery, MethodCallExpression? tvf, SyntaxToken? alias)
+        {
+            if (tableOrViewName is not null)
+                return new QuerySource(tableOrViewName, alias);
+            else if (subQuery is not null)
+                return new QuerySource(subQuery, alias);
+            else if (tvf is not null)
+                return new QuerySource(tvf,  alias);
+            else
+                throw new ArgumentException("At least one of tableOrViewName, subQuery or tvf must be non-null");
+        }
+    }
+
+}

--- a/src/SimpleDb/Parsing/Statement.cs
+++ b/src/SimpleDb/Parsing/Statement.cs
@@ -3,9 +3,6 @@
     public enum SyntaxKind
     {
         //select
-        Select,
-        Update,
-        Delete,
         Literal,
         Binary,
         Where,
@@ -17,7 +14,7 @@
         DeleteStatement,
         SubQuery,
 
-        //expresions
+        //expressions
         Star,
         Unary,
         ParenthesizedExpr,

--- a/src/SimpleDb/Parsing/Statement.cs
+++ b/src/SimpleDb/Parsing/Statement.cs
@@ -12,7 +12,9 @@
         SelectStatement,
         UpdateStatement,
         DeleteStatement,
+        TableAccess,
         SubQuery,
+        JoinExpression,
 
         //expressions
         Star,
@@ -21,10 +23,7 @@
         Assignment,
         MemberAccess,
         Alias,
-        MethodCall,
-
-        //table source
-        QuerySource
+        MethodCall
     }
     public abstract record class SyntaxNode
     {
@@ -34,52 +33,12 @@
     {
     }
 
-    public record class QuerySource : Statement
+    public enum JoinType {  Inner, Outer }
+
+    public record class JoinExpression(JoinType JoinType, Expression Left, Expression Right, Expression Condition)
+        : Expression
     {
-        public const int TableOrView = 0, SubQuery = 1, TVF = 2;
-
-        override public SyntaxKind Kind => SyntaxKind.QuerySource;
-        public QuerySource(SyntaxToken tableOrViewName, SyntaxToken? alias)
-        {
-            TableOrViewName = tableOrViewName;
-            Alias = alias;
-        }
-
-        public QuerySource(MethodCallExpression tvf, SyntaxToken? alias)
-        {
-            TableValuedFunction = tvf;
-            Alias = alias;
-            SubType = TVF;
-        }
-
-        public QuerySource(SubQuery nestedQuery, SyntaxToken? alias)
-        {
-            NestedQuery = nestedQuery;
-            Alias = alias;
-            SubType = SubQuery;
-        }
-
-        public SyntaxToken? TableOrViewName { get; }
-
-        public MethodCallExpression? TableValuedFunction { get; }
-
-        public SubQuery? NestedQuery { get; }
-
-        public SyntaxToken? Alias { get; }
-
-        public int SubType { get; } // 0=TableOrView, 1=SubQuery, 2=TVF
-
-        public static QuerySource FromOne(SyntaxToken? tableOrViewName, SubQuery? subQuery, MethodCallExpression? tvf, SyntaxToken? alias)
-        {
-            if (tableOrViewName is not null)
-                return new QuerySource(tableOrViewName, alias);
-            else if (subQuery is not null)
-                return new QuerySource(subQuery, alias);
-            else if (tvf is not null)
-                return new QuerySource(tvf,  alias);
-            else
-                throw new ArgumentException("At least one of tableOrViewName, subQuery or tvf must be non-null");
-        }
+        public override SyntaxKind Kind => SyntaxKind.JoinExpression;
     }
 
 }

--- a/src/SimpleDb/Parsing/SyntaxError.cs
+++ b/src/SimpleDb/Parsing/SyntaxError.cs
@@ -1,0 +1,4 @@
+﻿namespace SimpleDb.Parsing
+{
+    public record struct SyntaxError(string Message, int Start);
+}

--- a/src/SimpleDb/Parsing/SyntaxToken.cs
+++ b/src/SimpleDb/Parsing/SyntaxToken.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SimpleDb.Parsing
+{
+    public record class SyntaxToken(TokenType Type, string Lexeme, int Start, object? Literal);
+
+    public enum TokenType
+    {
+        None,
+        Select,
+        Update,
+        Delete,
+        Identifier,
+        Comma,
+        AS,
+        From,
+
+        //binary
+        Plus,
+        Minus,
+        Star,
+        Percent,
+        ForwardSlash,
+        Equal,
+        Bang,
+        BangEqual,
+        LessThan,
+        LessThanEqual,
+        GreaterThan,
+        GreaterThanEqual,
+        And,
+        Or,
+
+        //nonwords
+        LeftParen,
+        RightParen,
+
+
+        //values
+        IntValue,
+        StringValue
+    }
+}

--- a/src/SimpleDb/Parsing/SyntaxToken.cs
+++ b/src/SimpleDb/Parsing/SyntaxToken.cs
@@ -10,9 +10,15 @@
         Delete,
         Identifier,
         Comma,
+        Dot,
         As,
         From,
         Where,
+        Inner,
+        Outer,
+        Cross,
+        Join,
+        On,
 
         //binary
         Plus,

--- a/src/SimpleDb/Parsing/SyntaxToken.cs
+++ b/src/SimpleDb/Parsing/SyntaxToken.cs
@@ -10,7 +10,7 @@ namespace SimpleDb.Parsing
 
     public enum TokenType
     {
-        None,
+        EOF,
         Select,
         Update,
         Delete,

--- a/src/SimpleDb/Parsing/SyntaxToken.cs
+++ b/src/SimpleDb/Parsing/SyntaxToken.cs
@@ -16,8 +16,9 @@ namespace SimpleDb.Parsing
         Delete,
         Identifier,
         Comma,
-        AS,
+        As,
         From,
+        Where,
 
         //binary
         Plus,

--- a/src/SimpleDb/Parsing/SyntaxToken.cs
+++ b/src/SimpleDb/Parsing/SyntaxToken.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace SimpleDb.Parsing
+﻿namespace SimpleDb.Parsing
 {
     public record class SyntaxToken(TokenType Type, string Lexeme, int Start, object? Literal);
 

--- a/src/SimpleDb/Parsing/UpdateStatement.cs
+++ b/src/SimpleDb/Parsing/UpdateStatement.cs
@@ -1,0 +1,11 @@
+﻿namespace SimpleDb.Parsing
+{
+    public record class UpdateStatement(
+        SyntaxToken UpdateKeyword,
+        SyntaxToken Table,
+        SyntaxToken SetKeyword
+        ) : Statement
+    {
+        public override SyntaxKind Kind => SyntaxKind.UpdateStatement;
+    }
+}

--- a/src/SimpleDb/Query/QueryPredicate.cs
+++ b/src/SimpleDb/Query/QueryPredicate.cs
@@ -64,7 +64,7 @@ public class QueryPredicate
     {
         foreach (var term in _terms)
         {
-            var constant = term.GetEquatesWithConstantOrNull(fieldName);
+            var constant = term.EquatesWithConstant(fieldName);
             if (constant is not null)
                 return constant;
         }
@@ -75,7 +75,7 @@ public class QueryPredicate
     {
         foreach (var term in _terms)
         {
-            var field = term.GetEquatesWithFieldOrNull(fieldName);
+            var field = term.EquatesWithField(fieldName);
             if (field is not null)
                 return field;
         }

--- a/src/SimpleDb/Tx/Concurrency/LockTable.cs
+++ b/src/SimpleDb/Tx/Concurrency/LockTable.cs
@@ -49,7 +49,7 @@ namespace SimpleDb.Tx.Concurrency
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool HasTimedOut(DateTime startTime)
-            => DateTime.UtcNow.Subtract(startTime).TotalSeconds >= 10_000;
+            => DateTime.UtcNow.Subtract(startTime).TotalSeconds >= 10;
 
         public void UnLock(BlockId blockId)
         {

--- a/test/SimpleDb.UnitTests/Metadata/CatalogManagerUnitTests.cs
+++ b/test/SimpleDb.UnitTests/Metadata/CatalogManagerUnitTests.cs
@@ -14,11 +14,10 @@ public class TableManagerUnitTests : AbstractTxTest
     [Fact]
     public void Catalog_Tables_Are_Created()
     {
-        TableManager mgr = new(_tx, true);
-
+        TableManager mgr = new(_tx, true); //ensures catalogs are created.
         var tableCatalog = Path.Join(_fixture.FileManager.Directory.FullName, $"{TableManager.TableCatalog}.tbl");
         var fieldCatalog = Path.Join(_fixture.FileManager.Directory.FullName, $"{TableManager.FieldCatalog}.tbl");
-
+        _tx.Commit();
         Assert.True(File.Exists(tableCatalog));
         Assert.True(File.Exists(fieldCatalog));
     }

--- a/test/SimpleDb.UnitTests/Parsing/ParserTests_Expressions.cs
+++ b/test/SimpleDb.UnitTests/Parsing/ParserTests_Expressions.cs
@@ -1,0 +1,212 @@
+﻿using SimpleDb.Parsing;
+
+namespace SimpleDb.UnitTests.Parsing
+{
+    public partial class ParserTests
+    {
+        [Fact]
+        public void Parser_Simple_Arithmetic()
+        {
+            List<SyntaxToken> tokens = [
+                new(TokenType.Select, "select", 0, null),
+                new(TokenType.Identifier, "column1", 7, null),
+                new(TokenType.Star, "*", 8, null),
+                new(TokenType.IntValue, "100", 19, 100),
+                new(TokenType.Comma, ",", 14, null),
+                new(TokenType.Identifier, "column2", 16, null),
+                new(TokenType.From, "from", 24, null),
+                new(TokenType.Identifier, "table1", 29, null),
+                new(TokenType.EOF, "",40, null),
+                ];
+            var parser = new Parser(tokens);
+            var stmt = parser.Parse();
+            Assert.NotNull(stmt);
+            AssertIs<SelectStatement>(stmt, c =>
+            {
+                Assert.Equal(2, c.Values.Count);
+                Assert.IsType<BinaryExpression>(c.Values[0]);
+                BinaryExpression binaryExpression = (BinaryExpression)c.Values[0];
+                AssertIs<MemberAccessExpression>(binaryExpression.Left, me =>
+                {
+                    Assert.Equal("column1", me.Member.Lexeme);
+                });
+                Assert.Equal(TokenType.Star, binaryExpression.OperatorToken.Type);
+                AssertIs<LiteralExpression>(binaryExpression.Right, me =>
+                {
+                    Assert.Equal(100, me.LiteralToken.Literal);
+                });
+            });
+        }
+
+        [Fact]
+        public void Parser_Operator_Precedence()
+        {
+            List<SyntaxToken> tokens = [
+                new(TokenType.Select, "select", 0, null),
+                new(TokenType.Identifier, "column1", 7, null),
+                new(TokenType.Plus, "+", 15, null),
+                new(TokenType.Identifier, "column2", 16, null),
+                new(TokenType.Star, "*", 23, null),
+                new(TokenType.IntValue, "10", 24, 10),
+                new(TokenType.From, "from", 27, null),
+                new(TokenType.Identifier, "table1", 32, null),
+                new(TokenType.EOF, "",40, null),
+                ];
+            var parser = new Parser(tokens);
+            var stmt = parser.Parse();
+            Assert.NotNull(stmt);
+            AssertIs<SelectStatement>(stmt, c =>
+            {
+                Assert.Single(c.Values);
+                AssertIs<BinaryExpression>(c.Values[0], be =>
+                {
+                    AssertIs<MemberAccessExpression>(be.Left, me =>
+                    {
+                        Assert.Equal("column1", me.Member.Lexeme);
+                    });
+                    Assert.Equal(TokenType.Plus, be.OperatorToken.Type);
+                    AssertIs<BinaryExpression>(be.Right, rightBe =>
+                    {
+                        AssertIs<MemberAccessExpression>(rightBe.Left, me2 =>
+                        {
+                            Assert.Equal("column2", me2.Member.Lexeme);
+                        });
+                        Assert.Equal(TokenType.Star, rightBe.OperatorToken.Type);
+                        AssertIs<LiteralExpression>(rightBe.Right, le =>
+                        {
+                            Assert.Equal(10, le.LiteralToken.Literal);
+                        });
+                    });
+                });
+            });
+        }
+
+        [Fact]
+        public void Parser_Parenthesized_Expression()
+        {
+            List<SyntaxToken> tokens = [
+                new(TokenType.Select, "select", 0, null),
+                new(TokenType.LeftParen, "(", 7, null),
+                new(TokenType.Identifier, "column1", 8, null),
+                new(TokenType.Plus, "+", 15, null),
+                new(TokenType.IntValue, "50", 16, 50),
+                new(TokenType.RightParen, ")", 18, null),
+                new(TokenType.From, "from", 20, null),
+                new(TokenType.Identifier, "table1", 25, null),
+                new(TokenType.EOF, "",30, null),
+                ];
+            var parser = new Parser(tokens);
+            var stmt = parser.Parse();
+            Assert.NotNull(stmt);
+            AssertIs<SelectStatement>(stmt, c =>
+            {
+                Assert.Single(c.Values);
+                AssertIs<ParenthesizedExpression>(c.Values[0], pe =>
+                {
+                    AssertIs<BinaryExpression>(pe.InnerExpression, be =>
+                    {
+                        AssertIs<MemberAccessExpression>(be.Left, me =>
+                        {
+                            Assert.Equal("column1", me.Member.Lexeme);
+                        });
+                        Assert.Equal(TokenType.Plus, be.OperatorToken.Type);
+                        AssertIs<LiteralExpression>(be.Right, le =>
+                        {
+                            Assert.Equal(50, le.LiteralToken.Literal);
+                        });
+                    });
+                });
+            });
+        }
+
+        [Fact]
+        public void Parser_Nested_Expressions()
+        {
+            List<SyntaxToken> tokens = [
+                new(TokenType.Select, "select", 0, null),
+                new(TokenType.LeftParen, "(", 7, null),
+                new(TokenType.Identifier, "column1", 8, null),
+                new(TokenType.Plus, "+", 15, null),
+                new(TokenType.LeftParen, "(", 16, null),
+                new(TokenType.IntValue, "20", 17, 20),
+                new(TokenType.Star, "*", 19, null),
+                new(TokenType.Identifier, "column2", 20, null),
+                new(TokenType.RightParen, ")", 27, null),
+                new(TokenType.RightParen, ")", 28, null),
+                new(TokenType.From, "from", 30, null),
+                new(TokenType.Identifier, "table1", 35, null),
+                new(TokenType.EOF, "",40, null),
+                ];
+            var parser = new Parser(tokens);
+            var stmt = parser.Parse();
+            Assert.NotNull(stmt);
+            AssertIs<SelectStatement>(stmt, c =>
+            {
+                Assert.Single(c.Values);
+                AssertIs<ParenthesizedExpression>(c.Values[0], pe =>
+                {
+                    AssertIs<BinaryExpression>(pe.InnerExpression, be =>
+                    {
+                        AssertIs<MemberAccessExpression>(be.Left, me =>
+                        {
+                            Assert.Equal("column1", me.Member.Lexeme);
+                        });
+                        Assert.Equal(TokenType.Plus, be.OperatorToken.Type);
+                        AssertIs<ParenthesizedExpression>(be.Right, innerPe =>
+                        {
+                            AssertIs<BinaryExpression>(innerPe.InnerExpression, innerBe =>
+                            {
+                                AssertIs<LiteralExpression>(innerBe.Left, le =>
+                                {
+                                    Assert.Equal(20, le.LiteralToken.Literal);
+                                });
+                                Assert.Equal(TokenType.Star, innerBe.OperatorToken.Type);
+                                AssertIs<MemberAccessExpression>(innerBe.Right, me2 =>
+                                {
+                                    Assert.Equal("column2", me2.Member.Lexeme);
+                                });
+                            });
+                        });
+                    });
+                });
+            });
+        }
+
+        [Fact]
+        public void Parser_Aliasing_Columns()
+        {
+            List<SyntaxToken> tokens = [
+                new(TokenType.Select, "select", 0, null),
+                new(TokenType.Identifier, "column1", 7, null),
+                new(TokenType.As, "as", 15, null),
+                new(TokenType.Identifier, "col1_alias", 18, null),
+                new(TokenType.From, "from", 30, null),
+                new(TokenType.Identifier, "table1", 35, null),
+                new(TokenType.EOF, "",40, null),
+                ];
+            var parser = new Parser(tokens);
+            var stmt = parser.Parse();
+            Assert.NotNull(stmt);
+            AssertIs<SelectStatement>(stmt, c =>
+            {
+                Assert.Single(c.Values);
+                AssertIs<AliasExpression>(c.Values[0], ae =>
+                {
+                    AssertIs<MemberAccessExpression>(ae.Expression, me =>
+                    {
+                        Assert.Equal("column1", me.Member.Lexeme);
+                    });
+                    Assert.Equal("col1_alias", ae.Alias.Lexeme);
+                });
+            });
+        }
+
+        private static void AssertIs<T>(object value, Action<T> next)
+        {
+            Assert.NotNull(value);
+            Assert.IsType<T>(value);
+            T vt = (T)value;
+            next(vt);
+        }
+    }
+}

--- a/test/SimpleDb.UnitTests/Parsing/ParserTests_Expressions.cs
+++ b/test/SimpleDb.UnitTests/Parsing/ParserTests_Expressions.cs
@@ -208,5 +208,14 @@ namespace SimpleDb.UnitTests.Parsing
             T vt = (T)value;
             next(vt);
         }
+
+        private static void AssertAliasOf<T>(object value, string expectedAlias, Action<T> next)
+        {
+            Assert.NotNull(value);
+            Assert.IsType<AliasExpression>(value);
+            AliasExpression aliasExpression = (AliasExpression)value;
+            Assert.Equal(expectedAlias, aliasExpression.Alias.Lexeme);
+            AssertIs<T>(aliasExpression.Expression, next);
+        }
     }
 }

--- a/test/SimpleDb.UnitTests/Parsing/ParserTests_Query.cs
+++ b/test/SimpleDb.UnitTests/Parsing/ParserTests_Query.cs
@@ -25,10 +25,11 @@ namespace SimpleDb.UnitTests.Parsing
                 Assert.NotNull(valueExpr);
                 Assert.Equal(columns[i], valueExpr.Member.Lexeme);
             }
-
-            string[] tables = table.Split(',', StringSplitOptions.RemoveEmptyEntries);
-            Assert.NotNull(expression.From.Source.TableOrViewName);
-            Assert.Equal(tables[0], expression.From.Source.TableOrViewName.Lexeme);
+            AssertIs<MemberAccessExpression>(expression.From!.Source, ts =>
+            {
+                Assert.NotNull(ts.Member);
+                Assert.Equal(table, ts.Member.Lexeme);
+            });
 
         }
 
@@ -50,11 +51,11 @@ namespace SimpleDb.UnitTests.Parsing
                 Assert.NotNull(valueExpr);
                 Assert.Equal(columns[i], valueExpr.Member.Lexeme);
             }
-            string[] tables = table.Split(',', StringSplitOptions.RemoveEmptyEntries);
-            Assert.NotNull(expression.From.Source.TableOrViewName);
-            Assert.Equal(tables[0], expression.From.Source.TableOrViewName.Lexeme);
-            Assert.NotNull(expression.Where);
-            // Further assertions on the where clause can be added here
+            AssertIs<MemberAccessExpression>(expression.From!.Source, ts =>
+            {
+                Assert.NotNull(ts.Member);
+                Assert.Equal(table, ts.Member.Lexeme);
+            });
         }
 
         [Fact]
@@ -78,8 +79,15 @@ namespace SimpleDb.UnitTests.Parsing
                 {
                     Assert.Equal("column1", me.Member.Lexeme);
                 });
-                Assert.NotNull(c.From.Source.Alias);
-                Assert.Equal("t1", c.From.Source.Alias!.Lexeme);
+                AssertIs<AliasExpression>(c.From!.Source, alias =>
+                {
+                    Assert.Equal("t1", alias.Alias.Lexeme);
+                    AssertIs<MemberAccessExpression>(alias.Expression, ts =>
+                    {
+                        Assert.NotNull(ts.Member);
+                        Assert.Equal("table1", ts.Member.Lexeme);
+                    });
+                });
             });
         }
 
@@ -138,9 +146,27 @@ namespace SimpleDb.UnitTests.Parsing
                 {
                     Assert.Equal("column1", me.Member.Lexeme);
                 });
-                Assert.NotNull(c.From.Source.NestedQuery);
-                Assert.NotNull(c.From.Source.Alias);
-                Assert.Equal("t1", c.From.Source.Alias!.Lexeme);
+                AssertIs<AliasExpression>(c.From!.Source, alias =>
+                {
+                    Assert.Equal("t1", alias.Alias!.Lexeme);
+                    AssertIs<SubQuery>(alias.Expression, sq =>
+                    {
+                        Assert.NotNull(sq.Query);
+                        AssertIs<SelectStatement>(sq.Query, inner =>
+                        {
+                            Assert.Single(inner.Values);
+                            AssertIs<MemberAccessExpression>(inner.Values[0], me =>
+                            {
+                                Assert.Equal("column2", me.Member.Lexeme);
+                            });
+                            AssertIs<MemberAccessExpression>(inner.From!.Source, ts =>
+                            {
+                                Assert.Equal("table2", ts.Member.Lexeme);
+                            });
+                        });
+                    });
+                });
+                
             });
         }
 
@@ -172,9 +198,30 @@ namespace SimpleDb.UnitTests.Parsing
                 {
                     Assert.Equal("column1", me.Member.Lexeme);
                 });
-                Assert.NotNull(c.From.Source.NestedQuery);
-                Assert.NotNull(c.From.Source.Alias);
-                Assert.Equal("t1", c.From.Source.Alias!.Lexeme);
+                AssertIs<AliasExpression>(c.From!.Source, alias =>
+                {
+                    Assert.Equal("t1", alias.Alias!.Lexeme);
+                    AssertIs<SubQuery>(alias.Expression, sq =>
+                    {
+                        AssertIs<SelectStatement>(sq.Query, inner =>
+                        {
+                            Assert.Single(inner.Values);
+                            AssertIs<AliasExpression>(inner.Values[0], alias =>
+                            {
+                                AssertIs<MemberAccessExpression>(alias.Expression, me =>
+                                {
+                                    Assert.Equal("column2", me.Member.Lexeme);
+                                });
+                            });
+                            AssertIs<MemberAccessExpression>(inner.From!.Source, ts =>
+                            {
+                                Assert.NotNull(ts.Member);
+                                Assert.Equal("table2", ts.Member.Lexeme);
+                            });
+                        });
+                    });
+                    
+                });
             });
         }
 
@@ -253,10 +300,335 @@ namespace SimpleDb.UnitTests.Parsing
                 {
                     Assert.Equal("column1", me.Member.Lexeme);
                 });
-                AssertIs<MethodCallExpression>(c.From.Source.TableValuedFunction!, mce =>
+                AssertIs<MethodCallExpression>(c.From!.Source, mce =>
                 {
                     Assert.Equal("GetItems", mce.MethodName.Lexeme);
                     Assert.Empty(mce.Arguments);
+                });
+            });
+        }
+
+        [Fact]
+        public void Parse_TableValuedFunction_With_Arguments_Select()
+        {
+            List<SyntaxToken> tokens = [
+                new(TokenType.Select, "select", 0, null),
+                new(TokenType.Identifier, "column1", 7, null),
+                new(TokenType.From, "from", 15, null),
+                new(TokenType.Identifier, "GetItems", 20, null),
+                new(TokenType.LeftParen, "(", 28, null),
+                new(TokenType.IntValue, "100", 29, 100),
+                new(TokenType.RightParen, ")", 32, null),
+                new(TokenType.EOF, "", 34, null)
+                ];
+            var parser = new Parser(tokens);
+            var stmt = parser.Parse();
+            Assert.NotNull(stmt);
+            AssertIs<SelectStatement>(stmt, c =>
+            {
+                Assert.Single(c.Values);
+                AssertIs<MemberAccessExpression>(c.Values[0], me =>
+                {
+                    Assert.Equal("column1", me.Member.Lexeme);
+                });
+                AssertIs<MethodCallExpression>(c.From!.Source, mce =>
+                {
+                    Assert.Equal("GetItems", mce.MethodName.Lexeme);
+                    Assert.Single(mce.Arguments);
+                    AssertIs<LiteralExpression>(mce.Arguments[0], le =>
+                    {
+                        Assert.Equal(100, le.LiteralToken.Literal);
+                    });
+                });
+            });
+        }
+
+        //joins
+
+        [Fact]
+        public void Parse_SelectFromMultipleTablesWithJoin()
+        {
+            var query = "select u.id, u.name, count(o.id) as order_ct from users u join orders o on u.id = o.user_id";
+            var tokens = new Scanner(query).GetTokens();
+            var parser = new Parser(tokens);
+            var stmt = parser.Parse();
+            Assert.NotNull(stmt);
+            AssertIs<SelectStatement>(stmt, c =>
+            {
+                Assert.Equal(3,c.Values.Count);
+                AssertIs<MemberAccessExpression>(c.Values[0], me =>
+                {
+                    Assert.Equal("u", me.Object?.Lexeme);
+                    Assert.Equal("id", me.Member.Lexeme);
+                });
+                AssertIs<MemberAccessExpression>(c.Values[1], me =>
+                {
+                    Assert.Equal("u", me.Object?.Lexeme);
+                    Assert.Equal("name", me.Member.Lexeme);
+                });
+                AssertAliasOf<MethodCallExpression>(c.Values[2], "order_ct", me =>
+                {
+                    Assert.Equal("count", me.MethodName.Lexeme);
+                    Assert.Single(me.Arguments);
+                    AssertIs<MemberAccessExpression>(me.Arguments[0], arg =>
+                    {
+                        Assert.Equal("o", arg.Object?.Lexeme);
+                        Assert.Equal("id", arg.Member.Lexeme);
+                    });
+                });
+
+                AssertIs<JoinExpression>(c.From!.Source, je =>
+                {
+                    Assert.Equal(JoinType.Inner, je.JoinType);
+                    //left
+                    AssertIs<AliasExpression>(je.Left, left =>
+                    {
+                        Assert.Equal("u", left.Alias?.Lexeme);
+                        AssertIs<MemberAccessExpression>(left.Expression, t =>
+                        {
+                            Assert.Equal("users", t.Member.Lexeme);
+                        });
+                    });
+                    //right
+                    AssertIs<AliasExpression>(je.Right, right =>
+                    {
+                        Assert.Equal("o", right.Alias.Lexeme);
+                        AssertIs<MemberAccessExpression>(right.Expression, m =>
+                        {
+                            Assert.Equal("orders", m.Member.Lexeme);
+                        });
+                    });
+                    //condition
+                    AssertIs<BinaryExpression>(je.Condition, binary =>
+                    {
+                        Assert.Equal(TokenType.Equal, binary.OperatorToken.Type);
+                        AssertIs<MemberAccessExpression>(binary.Left, left =>
+                        {
+                            Assert.Equal("u", left.Object?.Lexeme);
+                            Assert.Equal("id", left.Member.Lexeme);
+                        });
+                        AssertIs<MemberAccessExpression>(binary.Right, right =>
+                        {
+                            Assert.Equal("o", right.Object?.Lexeme);
+                            Assert.Equal("user_id", right.Member.Lexeme);
+                        });
+                    });
+                });
+            });
+        }
+
+        [Fact]
+        public void Parse_SelectFromMultipleTablesWithCommaJoin()
+        {
+            var query = "select u.id, u.name, count(o.id) as order_ct from users u, orders o on u.id = o.user_id";
+            var tokens = new Scanner(query).GetTokens();
+            var parser = new Parser(tokens);
+            var stmt = parser.Parse();
+            Assert.NotNull(stmt);
+            AssertIs<SelectStatement>(stmt, c =>
+            {
+                Assert.Equal(3, c.Values.Count);
+                AssertIs<MemberAccessExpression>(c.Values[0], me =>
+                {
+                    Assert.Equal("u", me.Object?.Lexeme);
+                    Assert.Equal("id", me.Member.Lexeme);
+                });
+                AssertIs<MemberAccessExpression>(c.Values[1], me =>
+                {
+                    Assert.Equal("u", me.Object?.Lexeme);
+                    Assert.Equal("name", me.Member.Lexeme);
+                });
+                AssertAliasOf<MethodCallExpression>(c.Values[2], "order_ct", me =>
+                {
+                    Assert.Equal("count", me.MethodName.Lexeme);
+                    Assert.Single(me.Arguments);
+                    AssertIs<MemberAccessExpression>(me.Arguments[0], arg =>
+                    {
+                        Assert.Equal("o", arg.Object?.Lexeme);
+                        Assert.Equal("id", arg.Member.Lexeme);
+                    });
+                });
+
+                AssertIs<JoinExpression>(c.From!.Source, je =>
+                {
+                    Assert.Equal(JoinType.Inner, je.JoinType);
+                    //left
+                    AssertIs<AliasExpression>(je.Left, left =>
+                    {
+                        Assert.Equal("u", left.Alias?.Lexeme);
+                        AssertIs<MemberAccessExpression>(left.Expression, t =>
+                        {
+                            Assert.Equal("users", t.Member.Lexeme);
+                        });
+                    });
+                    //right
+                    AssertIs<AliasExpression>(je.Right, right =>
+                    {
+                        Assert.Equal("o", right.Alias.Lexeme);
+                        AssertIs<MemberAccessExpression>(right.Expression, m =>
+                        {
+                            Assert.Equal("orders", m.Member.Lexeme);
+                        });
+                    });
+                    //condition
+                    AssertIs<BinaryExpression>(je.Condition, binary =>
+                    {
+                        Assert.Equal(TokenType.Equal, binary.OperatorToken.Type);
+                        AssertIs<MemberAccessExpression>(binary.Left, left =>
+                        {
+                            Assert.Equal("u", left.Object?.Lexeme);
+                            Assert.Equal("id", left.Member.Lexeme);
+                        });
+                        AssertIs<MemberAccessExpression>(binary.Right, right =>
+                        {
+                            Assert.Equal("o", right.Object?.Lexeme);
+                            Assert.Equal("user_id", right.Member.Lexeme);
+                        });
+                    });
+                });
+            });
+        }
+
+        [Fact]
+        public void Parse_SelectFromMultipleTablesWithInnerJoin()
+        {
+            var query = "select u.id, u.name, count(o.id) as order_ct from users u inner join orders o on u.id = o.user_id";
+            var tokens = new Scanner(query).GetTokens();
+            var parser = new Parser(tokens);
+            var stmt = parser.Parse();
+            Assert.NotNull(stmt);
+            AssertIs<SelectStatement>(stmt, c =>
+            {
+                Assert.Equal(3, c.Values.Count);
+                AssertIs<MemberAccessExpression>(c.Values[0], me =>
+                {
+                    Assert.Equal("u", me.Object?.Lexeme);
+                    Assert.Equal("id", me.Member.Lexeme);
+                });
+                AssertIs<MemberAccessExpression>(c.Values[1], me =>
+                {
+                    Assert.Equal("u", me.Object?.Lexeme);
+                    Assert.Equal("name", me.Member.Lexeme);
+                });
+                AssertAliasOf<MethodCallExpression>(c.Values[2], "order_ct", me =>
+                {
+                    Assert.Equal("count", me.MethodName.Lexeme);
+                    Assert.Single(me.Arguments);
+                    AssertIs<MemberAccessExpression>(me.Arguments[0], arg =>
+                    {
+                        Assert.Equal("o", arg.Object?.Lexeme);
+                        Assert.Equal("id", arg.Member.Lexeme);
+                    });
+                });
+
+                AssertIs<JoinExpression>(c.From!.Source, je =>
+                {
+                    Assert.Equal(JoinType.Inner, je.JoinType);
+                    //left
+                    AssertIs<AliasExpression>(je.Left, left =>
+                    {
+                        Assert.Equal("u", left.Alias?.Lexeme);
+                        AssertIs<MemberAccessExpression>(left.Expression, t =>
+                        {
+                            Assert.Equal("users", t.Member.Lexeme);
+                        });
+                    });
+                    //right
+                    AssertIs<AliasExpression>(je.Right, right =>
+                    {
+                        Assert.Equal("o", right.Alias.Lexeme);
+                        AssertIs<MemberAccessExpression>(right.Expression, m =>
+                        {
+                            Assert.Equal("orders", m.Member.Lexeme);
+                        });
+                    });
+                    //condition
+                    AssertIs<BinaryExpression>(je.Condition, binary =>
+                    {
+                        Assert.Equal(TokenType.Equal, binary.OperatorToken.Type);
+                        AssertIs<MemberAccessExpression>(binary.Left, left =>
+                        {
+                            Assert.Equal("u", left.Object?.Lexeme);
+                            Assert.Equal("id", left.Member.Lexeme);
+                        });
+                        AssertIs<MemberAccessExpression>(binary.Right, right =>
+                        {
+                            Assert.Equal("o", right.Object?.Lexeme);
+                            Assert.Equal("user_id", right.Member.Lexeme);
+                        });
+                    });
+                });
+            });
+        }
+
+        [Fact]
+        public void Parse_SelectFromMultipleTablesWithOuterJoin()
+        {
+            var query = "select u.id, u.name, count(o.id) as order_ct from users u outer join orders o on u.id = o.user_id";
+            var tokens = new Scanner(query).GetTokens();
+            var parser = new Parser(tokens);
+            var stmt = parser.Parse();
+            Assert.NotNull(stmt);
+            AssertIs<SelectStatement>(stmt, c =>
+            {
+                Assert.Equal(3, c.Values.Count);
+                AssertIs<MemberAccessExpression>(c.Values[0], me =>
+                {
+                    Assert.Equal("u", me.Object?.Lexeme);
+                    Assert.Equal("id", me.Member.Lexeme);
+                });
+                AssertIs<MemberAccessExpression>(c.Values[1], me =>
+                {
+                    Assert.Equal("u", me.Object?.Lexeme);
+                    Assert.Equal("name", me.Member.Lexeme);
+                });
+                AssertAliasOf<MethodCallExpression>(c.Values[2], "order_ct", me =>
+                {
+                    Assert.Equal("count", me.MethodName.Lexeme);
+                    Assert.Single(me.Arguments);
+                    AssertIs<MemberAccessExpression>(me.Arguments[0], arg =>
+                    {
+                        Assert.Equal("o", arg.Object?.Lexeme);
+                        Assert.Equal("id", arg.Member.Lexeme);
+                    });
+                });
+
+                AssertIs<JoinExpression>(c.From!.Source, je =>
+                {
+                    Assert.Equal(JoinType.Outer, je.JoinType);
+                    //left
+                    AssertIs<AliasExpression>(je.Left, left =>
+                    {
+                        Assert.Equal("u", left.Alias?.Lexeme);
+                        AssertIs<MemberAccessExpression>(left.Expression, t =>
+                        {
+                            Assert.Equal("users", t.Member.Lexeme);
+                        });
+                    });
+                    //right
+                    AssertIs<AliasExpression>(je.Right, right =>
+                    {
+                        Assert.Equal("o", right.Alias.Lexeme);
+                        AssertIs<MemberAccessExpression>(right.Expression, m =>
+                        {
+                            Assert.Equal("orders", m.Member.Lexeme);
+                        });
+                    });
+                    //condition
+                    AssertIs<BinaryExpression>(je.Condition, binary =>
+                    {
+                        Assert.Equal(TokenType.Equal, binary.OperatorToken.Type);
+                        AssertIs<MemberAccessExpression>(binary.Left, left =>
+                        {
+                            Assert.Equal("u", left.Object?.Lexeme);
+                            Assert.Equal("id", left.Member.Lexeme);
+                        });
+                        AssertIs<MemberAccessExpression>(binary.Right, right =>
+                        {
+                            Assert.Equal("o", right.Object?.Lexeme);
+                            Assert.Equal("user_id", right.Member.Lexeme);
+                        });
+                    });
                 });
             });
         }

--- a/test/SimpleDb.UnitTests/Parsing/ParserTests_Query.cs
+++ b/test/SimpleDb.UnitTests/Parsing/ParserTests_Query.cs
@@ -1,0 +1,355 @@
+﻿using SimpleDb.Parsing;
+
+namespace SimpleDb.UnitTests.Parsing
+{
+    public partial class ParserTests
+    {
+
+        [Theory]
+        [MemberData(nameof(GetSimpleQueries))]
+        public void Parser_ParseSelectExpression_ReturnsQueryExpression(List<SyntaxToken> tokens, string column, string table)
+        {
+            var parser = new Parser(tokens);
+            // Act
+            var expression = parser.Parse() as SelectStatement;
+            // Assert
+            Assert.NotNull(expression);
+            Assert.Equal(SyntaxKind.SelectStatement, expression.Kind);
+
+            string[] columns = column.Split(',', StringSplitOptions.RemoveEmptyEntries);
+
+            Assert.Equal(columns.Length, expression.Values.Count);
+            for (int i = 0; i < columns.Length; i++)
+            {
+                var valueExpr = expression.Values[i] as MemberAccessExpression;
+                Assert.NotNull(valueExpr);
+                Assert.Equal(columns[i], valueExpr.Member.Lexeme);
+            }
+
+            string[] tables = table.Split(',', StringSplitOptions.RemoveEmptyEntries);
+            Assert.NotNull(expression.From.Source.TableOrViewName);
+            Assert.Equal(tables[0], expression.From.Source.TableOrViewName.Lexeme);
+
+        }
+
+
+        [Theory, MemberData(nameof(GetFilteredQueries))]
+        public void Parser_ParseFilteredSelectExpression_ReturnsQueryExpression(List<SyntaxToken> tokens, string column, string table)
+        {
+            var parser = new Parser(tokens);
+            // Act
+            var expression = parser.Parse() as SelectStatement;
+            // Assert
+            Assert.NotNull(expression);
+            Assert.Equal(SyntaxKind.SelectStatement, expression.Kind);
+            string[] columns = column.Split(',', StringSplitOptions.RemoveEmptyEntries);
+            Assert.Equal(columns.Length, expression.Values.Count);
+            for (int i = 0; i < columns.Length; i++)
+            {
+                var valueExpr = expression.Values[i] as MemberAccessExpression;
+                Assert.NotNull(valueExpr);
+                Assert.Equal(columns[i], valueExpr.Member.Lexeme);
+            }
+            string[] tables = table.Split(',', StringSplitOptions.RemoveEmptyEntries);
+            Assert.NotNull(expression.From.Source.TableOrViewName);
+            Assert.Equal(tables[0], expression.From.Source.TableOrViewName.Lexeme);
+            Assert.NotNull(expression.Where);
+            // Further assertions on the where clause can be added here
+        }
+
+        [Fact]
+        public void Parse_Table_Alias()
+        {
+            List<SyntaxToken> tokens = [
+                new(TokenType.Select, "select", 0, null),
+                new(TokenType.Identifier, "column1", 7, null),
+                new(TokenType.From, "from", 15, null),
+                new(TokenType.Identifier, "table1", 20, null),
+                new(TokenType.Identifier, "t1", 27, null),
+                new(TokenType.EOF, "", 29, null)
+                ];
+            var parser = new Parser(tokens);
+            var stmt = parser.Parse();
+            Assert.NotNull(stmt);
+            AssertIs<SelectStatement>(stmt, c =>
+            {
+                Assert.Single(c.Values);
+                AssertIs<MemberAccessExpression>(c.Values[0], me =>
+                {
+                    Assert.Equal("column1", me.Member.Lexeme);
+                });
+                Assert.NotNull(c.From.Source.Alias);
+                Assert.Equal("t1", c.From.Source.Alias!.Lexeme);
+            });
+        }
+
+        [Fact]
+        public void Parse_Column_Alias()
+        {
+            List<SyntaxToken> tokens = [
+                new(TokenType.Select, "select", 0, null),
+                new(TokenType.Identifier, "column1", 7, null),
+                new(TokenType.As, "as", 14, null),
+                new(TokenType.Identifier, "col1", 17, null),
+                new(TokenType.From, "from", 22, null),
+                new(TokenType.Identifier, "table1", 27, null),
+                new(TokenType.EOF, "", 33, null)
+                ];
+            var parser = new Parser(tokens);
+            var stmt = parser.Parse();
+            Assert.NotNull(stmt);
+            AssertIs<SelectStatement>(stmt, c =>
+            {
+                Assert.Single(c.Values);
+                AssertIs<AliasExpression>(c.Values[0], ae =>
+                {
+                    AssertIs<MemberAccessExpression>(ae.Expression, me =>
+                    {
+                        Assert.Equal("column1", me.Member.Lexeme);
+                    });
+                    Assert.Equal("col1", ae.Alias.Lexeme);
+                });
+            });
+        }
+
+        [Fact]
+        public void Parse_NestedQuery()
+        {
+            List<SyntaxToken> tokens = [
+                new(TokenType.Select, "select", 0, null),
+                new(TokenType.Identifier, "column1", 7, null),
+                new(TokenType.From, "from", 15, null),
+                new(TokenType.LeftParen, "(", 20, null),
+                new(TokenType.Select, "select", 21, null),
+                new(TokenType.Identifier, "column2", 28, null),
+                new(TokenType.From, "from", 36, null),
+                new(TokenType.Identifier, "table2", 41, null),
+                new(TokenType.RightParen, ")", 47, null),
+                new(TokenType.Identifier, "t1", 49, null),
+                new(TokenType.EOF, "", 51, null)
+                ];
+            var parser = new Parser(tokens);
+            var stmt = parser.Parse();
+            Assert.NotNull(stmt);
+            AssertIs<SelectStatement>(stmt, c =>
+            {
+                Assert.Single(c.Values);
+                AssertIs<MemberAccessExpression>(c.Values[0], me =>
+                {
+                    Assert.Equal("column1", me.Member.Lexeme);
+                });
+                Assert.NotNull(c.From.Source.NestedQuery);
+                Assert.NotNull(c.From.Source.Alias);
+                Assert.Equal("t1", c.From.Source.Alias!.Lexeme);
+            });
+        }
+
+        [Fact]
+        public void Parse_NestedQuery_With_Alias()
+        {
+            List<SyntaxToken> tokens = [
+                new(TokenType.Select, "select", 0, null),
+                new(TokenType.Identifier, "column1", 7, null),
+                new(TokenType.From, "from", 15, null),
+                new(TokenType.LeftParen, "(", 20, null),
+                new(TokenType.Select, "select", 21, null),
+                new(TokenType.Identifier, "column2", 28, null),
+                new(TokenType.As, "as", 35, null),
+                new(TokenType.Identifier, "col2", 38, null),
+                new(TokenType.From, "from", 43, null),
+                new(TokenType.Identifier, "table2", 48, null),
+                new(TokenType.RightParen, ")", 54, null),
+                new(TokenType.Identifier, "t1", 56, null),
+                new(TokenType.EOF, "", 58, null)
+                ];
+            var parser = new Parser(tokens);
+            var stmt = parser.Parse();
+            Assert.NotNull(stmt);
+            AssertIs<SelectStatement>(stmt, c =>
+            {
+                Assert.Single(c.Values);
+                AssertIs<MemberAccessExpression>(c.Values[0], me =>
+                {
+                    Assert.Equal("column1", me.Member.Lexeme);
+                });
+                Assert.NotNull(c.From.Source.NestedQuery);
+                Assert.NotNull(c.From.Source.Alias);
+                Assert.Equal("t1", c.From.Source.Alias!.Lexeme);
+            });
+        }
+
+        [Fact]
+        public void Parse_SelectAllColumns()
+        {
+            List<SyntaxToken> tokens = [
+                new(TokenType.Select, "select", 0, null),
+                new(TokenType.Star, "*", 7, null),
+                new(TokenType.From, "from", 9, null),
+                new(TokenType.Identifier, "table1", 14, null),
+                new(TokenType.EOF, "", 20, null)
+                ];
+            var parser = new Parser(tokens);
+            var stmt = parser.Parse();
+            Assert.NotNull(stmt);
+            AssertIs<SelectStatement>(stmt, c =>
+            {
+                Assert.Single(c.Values);
+                AssertIs<StarExpression>(c.Values[0], se =>
+                {
+                });
+            });
+        }
+
+        [Fact]
+        public void Parse_Method_Call_In_Select()
+        {
+            List<SyntaxToken> tokens = [
+                new(TokenType.Select, "select", 0, null),
+                new(TokenType.Identifier, "MAX", 7, null),
+                new(TokenType.LeftParen, "(", 10, null),
+                new(TokenType.Identifier, "column1", 11, null),
+                new(TokenType.RightParen, ")", 18, null),
+                new(TokenType.From, "from", 20, null),
+                new(TokenType.Identifier, "table1", 25, null),
+                new(TokenType.EOF, "", 31, null)
+                ];
+            var parser = new Parser(tokens);
+            var stmt = parser.Parse();
+            Assert.NotNull(stmt);
+            AssertIs<SelectStatement>(stmt, c =>
+            {
+                Assert.Single(c.Values);
+                AssertIs<MethodCallExpression>(c.Values[0], mce =>
+                {
+                    Assert.Equal("MAX", mce.MethodName.Lexeme);
+                    Assert.Single(mce.Arguments);
+                    AssertIs<MemberAccessExpression>(mce.Arguments[0], me =>
+                    {
+                        Assert.Equal("column1", me.Member.Lexeme);
+                    });
+                });
+            });
+        }
+
+        [Fact]
+        public void Parse_TableValuedFunction_Select()
+        {
+            List<SyntaxToken> tokens = [
+                new(TokenType.Select, "select", 0, null),
+                new(TokenType.Identifier, "column1", 7, null),
+                new(TokenType.From, "from", 15, null),
+                new(TokenType.Identifier, "GetItems", 20, null),
+                new(TokenType.LeftParen, "(", 28, null),
+                new(TokenType.RightParen, ")", 29, null),
+                new(TokenType.EOF, "", 31, null)
+                ];
+            var parser = new Parser(tokens);
+            var stmt = parser.Parse();
+            Assert.NotNull(stmt);
+            AssertIs<SelectStatement>(stmt, c =>
+            {
+                Assert.Single(c.Values);
+                AssertIs<MemberAccessExpression>(c.Values[0], me =>
+                {
+                    Assert.Equal("column1", me.Member.Lexeme);
+                });
+                AssertIs<MethodCallExpression>(c.From.Source.TableValuedFunction!, mce =>
+                {
+                    Assert.Equal("GetItems", mce.MethodName.Lexeme);
+                    Assert.Empty(mce.Arguments);
+                });
+            });
+        }
+
+        public static IEnumerable<object[]> GetSimpleQueries()
+        {
+            yield return [
+                new List<SyntaxToken>
+                {
+                    new(TokenType.Select, "select", 0, null),
+                    new(TokenType.Identifier, "column1", 7, null),
+                    new(TokenType.From, "from", 15, null),
+                    new(TokenType.Identifier, "table1", 20, null),
+                    new(TokenType.EOF, "", 26, null)
+                },
+                "column1",
+                "table1"
+            ];
+
+            yield return [
+                new List<SyntaxToken>
+                {
+                    new(TokenType.Select, "select", 0, null),
+                    new(TokenType.Identifier, "column1", 7, null),
+                    new(TokenType.Comma, ",", 14, null),
+                    new(TokenType.Identifier, "column2", 16, null),
+                    new(TokenType.From, "from", 24, null),
+                    new(TokenType.Identifier, "table1", 29, null),
+                    new(TokenType.EOF, "", 35, null)
+                },
+                "column1,column2",
+                "table1"
+            ];
+        }
+
+        public static IEnumerable<object[]> GetFilteredQueries()
+        {
+            yield return [
+                new List<SyntaxToken>
+                {
+                    new(TokenType.Select, "select", 0, null),
+                    new(TokenType.Identifier, "column1", 7, null),
+                    new(TokenType.From, "from", 15, null),
+                    new(TokenType.Identifier, "table1", 20, null),
+                    new(TokenType.Where, "where", 27, null),
+                    new(TokenType.Identifier, "column1", 33, null),
+                    new(TokenType.Equal, "=", 41, null),
+                    new(TokenType.IntValue, "100", 43, 100),
+                    new(TokenType.EOF, "", 26, null)
+                },
+                "column1",
+                "table1"
+            ];
+
+            yield return [
+                new List<SyntaxToken>
+                {
+                    new(TokenType.Select, "select", 0, null),
+                    new(TokenType.Identifier, "column1", 7, null),
+                    new(TokenType.Comma, ",", 14, null),
+                    new(TokenType.Identifier, "column2", 16, null),
+                    new(TokenType.From, "from", 24, null),
+                    new(TokenType.Identifier, "table1", 29, null),
+                    new(TokenType.Where, "where", 36, null),
+                    new(TokenType.Identifier, "column2", 42, null),
+                    new(TokenType.LessThan, "<", 50, null),
+                    new(TokenType.IntValue, "200", 52, 200),
+                    new(TokenType.EOF, "", 35, null)
+                },
+                "column1,column2",
+                "table1"
+            ];
+
+            yield return [
+                new List<SyntaxToken>
+                {
+                    new(TokenType.Select, "select", 0, null),
+                    new(TokenType.Identifier, "column1", 7, null),
+                    new(TokenType.From, "from", 15, null),
+                    new(TokenType.Identifier, "table1", 20, null),
+                    new(TokenType.Where, "where", 27, null),
+                    new(TokenType.Identifier, "column2", 33, null),
+                    new(TokenType.GreaterThan, ">", 41, null),
+                    new(TokenType.IntValue, "50", 43, 50),
+                    new(TokenType.Or, "or", 46, null),
+                    new(TokenType.Identifier, "column1", 49, null),
+                    new(TokenType.LessThanEqual, "<=", 57, null),
+                    new(TokenType.IntValue, "10", 60, 10),
+                    new(TokenType.EOF, "", 45, null)
+                },
+                "column1",
+                "table1"
+            ];
+        }
+    }
+}

--- a/test/SimpleDb.UnitTests/Parsing/ScannerTests.cs
+++ b/test/SimpleDb.UnitTests/Parsing/ScannerTests.cs
@@ -28,9 +28,10 @@ public class ScannerTests
         var tokens = scanner.GetTokens();
 
         // Assert
-        Assert.Single(tokens);
+        Assert.Equal(2, tokens.Count);
         Assert.Equal(expectedType, tokens[0].Type);
         Assert.Equal(keyword, tokens[0].Lexeme);
+        Assert.Equal(TokenType.EOF, tokens[^1].Type);
         Assert.Empty(scanner.SyntaxErrors);
     }
 
@@ -54,10 +55,11 @@ public class ScannerTests
         }
         else
         {
-            Assert.Single(tokens);
+            Assert.Equal(2, tokens.Count);
             Assert.Equal(TokenType.Identifier, tokens[0].Type);
             Assert.Equal(expectedLexeme, tokens[0].Lexeme);
             Assert.Equal(expectedLexeme, tokens[0].Literal);
+            Assert.Equal(TokenType.EOF, tokens[^1].Type);
         }
     }
 
@@ -75,9 +77,10 @@ public class ScannerTests
         var tokens = scanner.GetTokens();
 
         // Assert
-        Assert.Single(tokens);
+        Assert.Equal(2, tokens.Count);
         Assert.Equal(TokenType.IntValue, tokens[0].Type);
         Assert.Equal(expectedValue, tokens[0].Literal);
+        Assert.Equal(TokenType.EOF, tokens[^1].Type);
     }
 
     [Theory]
@@ -95,9 +98,10 @@ public class ScannerTests
         var tokens = scanner.GetTokens();
 
         // Assert
-        Assert.Single(tokens);
+        Assert.Equal(2, tokens.Count);
         Assert.Equal(TokenType.StringValue, tokens[0].Type);
         Assert.Equal(expectedValue, tokens[0].Literal);
+        Assert.Equal(TokenType.EOF, tokens[^1].Type);
     }
 
     [Theory]
@@ -121,8 +125,9 @@ public class ScannerTests
         var tokens = scanner.GetTokens();
 
         // Assert
-        Assert.Single(tokens);
+        Assert.Equal(2, tokens.Count);
         Assert.Equal(expectedType, tokens[0].Type);
+        Assert.Equal(TokenType.EOF, tokens[^1].Type);
         Assert.Equal(op, tokens[0].Lexeme);
     }
 
@@ -139,8 +144,9 @@ public class ScannerTests
         var tokens = scanner.GetTokens();
 
         // Assert
-        Assert.Single(tokens);
+        Assert.Equal(2, tokens.Count);
         Assert.Equal(expectedType, tokens[0].Type);
+        Assert.Equal(TokenType.EOF, tokens[^1].Type);
         Assert.Equal(op, tokens[0].Lexeme);
     }
 
@@ -155,13 +161,14 @@ public class ScannerTests
         var tokens = scanner.GetTokens();
 
         // Assert
-        Assert.Equal(4, tokens.Count);
+        Assert.Equal(5, tokens.Count);
         Assert.Equal(TokenType.Select, tokens[0].Type);
         Assert.Equal(TokenType.Identifier, tokens[1].Type);
         Assert.Equal("id", tokens[1].Literal);
         Assert.Equal(TokenType.From, tokens[2].Type);
         Assert.Equal(TokenType.Identifier, tokens[3].Type);
         Assert.Equal("users", tokens[3].Literal);
+        Assert.Equal(TokenType.EOF, tokens[^1].Type);
         Assert.Empty(scanner.SyntaxErrors);
     }
 
@@ -176,7 +183,7 @@ public class ScannerTests
         var tokens = scanner.GetTokens();
 
         // Assert
-        Assert.Equal(8, tokens.Count);
+        Assert.Equal(9, tokens.Count);
         Assert.Equal(TokenType.Select, tokens[0].Type);
         Assert.Equal(TokenType.Identifier, tokens[1].Type);
         Assert.Equal(TokenType.Plus, tokens[2].Type);
@@ -187,6 +194,7 @@ public class ScannerTests
         Assert.Equal(2, tokens[5].Literal);
         Assert.Equal(TokenType.From, tokens[6].Type);
         Assert.Equal(TokenType.Identifier, tokens[7].Type);
+        Assert.Equal(TokenType.EOF, tokens[^1].Type);
     }
 
     [Fact]
@@ -200,7 +208,7 @@ public class ScannerTests
         var tokens = scanner.GetTokens();
 
         // Assert
-        Assert.Equal(8, tokens.Count);
+        Assert.Equal(9, tokens.Count);
         Assert.Equal(TokenType.Select, tokens[0].Type);
         Assert.Equal(TokenType.LeftParen, tokens[1].Type);
         Assert.Equal(TokenType.Identifier, tokens[2].Type);
@@ -209,6 +217,7 @@ public class ScannerTests
         Assert.Equal(TokenType.RightParen, tokens[5].Type);
         Assert.Equal(TokenType.From, tokens[6].Type);
         Assert.Equal(TokenType.Identifier, tokens[7].Type);
+        Assert.Equal(TokenType.EOF, tokens[^1].Type);
     }
 
     [Fact]
@@ -222,11 +231,12 @@ public class ScannerTests
         var tokens = scanner.GetTokens();
 
         // Assert
-        Assert.Equal(4, tokens.Count);
+        Assert.Equal(5, tokens.Count);
         Assert.Equal(TokenType.Select, tokens[0].Type);
         Assert.Equal(TokenType.Identifier, tokens[1].Type);
         Assert.Equal(TokenType.From, tokens[2].Type);
         Assert.Equal(TokenType.Identifier, tokens[3].Type);
+        Assert.Equal(TokenType.EOF, tokens[^1].Type);
     }
 
     [Fact]
@@ -240,7 +250,7 @@ public class ScannerTests
         var tokens = scanner.GetTokens();
 
         // Assert
-        Assert.Equal(11, tokens.Count);
+        Assert.Equal(12, tokens.Count);
         Assert.Equal(TokenType.Identifier, tokens[0].Type);
         Assert.Equal(TokenType.Equal, tokens[1].Type);
         Assert.Equal(TokenType.IntValue, tokens[2].Type);
@@ -253,6 +263,7 @@ public class ScannerTests
         Assert.Equal(TokenType.BangEqual, tokens[9].Type);
         Assert.Equal(TokenType.StringValue, tokens[10].Type);
         Assert.Equal("active", tokens[10].Literal);
+        Assert.Equal(TokenType.EOF, tokens[^1].Type);
     }
 
     [Fact]
@@ -266,11 +277,12 @@ public class ScannerTests
         var tokens = scanner.GetTokens();
 
         // Assert
-        Assert.Equal(4, tokens.Count);
+        Assert.Equal(5, tokens.Count);
         Assert.Equal(TokenType.Select, tokens[0].Type);
         Assert.Equal(TokenType.Identifier, tokens[1].Type);
         Assert.Equal(TokenType.From, tokens[2].Type);
         Assert.Equal(TokenType.Identifier, tokens[3].Type);
+        Assert.Equal(TokenType.EOF, tokens[^1].Type);
     }
 
     [Fact]
@@ -298,8 +310,9 @@ public class ScannerTests
         var tokens = scanner.GetTokens();
 
         // Assert
-        Assert.Empty(tokens);
+        Assert.Single(tokens);
         Assert.Empty(scanner.SyntaxErrors);
+        Assert.Equal(TokenType.EOF, tokens[^1].Type);
     }
 
     [Fact]
@@ -312,7 +325,8 @@ public class ScannerTests
         var tokens = scanner.GetTokens();
 
         // Assert
-        Assert.Empty(tokens);
+        Assert.Single(tokens);
+        Assert.Equal(TokenType.EOF, tokens[^1].Type);
         Assert.Empty(scanner.SyntaxErrors);
     }
 
@@ -327,10 +341,11 @@ public class ScannerTests
         var tokens = scanner.GetTokens();
 
         // Assert
-        Assert.Equal(2, tokens.Count);
+        Assert.Equal(3, tokens.Count);
         Assert.Equal(TokenType.Update, tokens[0].Type);
         Assert.Equal(TokenType.Identifier, tokens[1].Type);
         Assert.Equal("users", tokens[1].Literal);
+        Assert.Equal(TokenType.EOF, tokens[^1].Type);
     }
 
     [Fact]
@@ -344,10 +359,11 @@ public class ScannerTests
         var tokens = scanner.GetTokens();
 
         // Assert
-        Assert.Equal(3, tokens.Count);
+        Assert.Equal(4, tokens.Count);
         Assert.Equal(TokenType.Delete, tokens[0].Type);
         Assert.Equal(TokenType.From, tokens[1].Type);
         Assert.Equal(TokenType.Identifier, tokens[2].Type);
+        Assert.Equal(TokenType.EOF, tokens[^1].Type);
     }
 
     [Fact]
@@ -361,7 +377,7 @@ public class ScannerTests
         var tokens = scanner.GetTokens();
 
         // Assert
-        Assert.Equal(11, tokens.Count);
+        Assert.Equal(12, tokens.Count);
         Assert.Equal(TokenType.IntValue, tokens[0].Type);
         Assert.Equal(TokenType.Plus, tokens[1].Type);
         Assert.Equal(TokenType.IntValue, tokens[2].Type);
@@ -373,6 +389,7 @@ public class ScannerTests
         Assert.Equal(TokenType.IntValue, tokens[8].Type);
         Assert.Equal(TokenType.Percent, tokens[9].Type);
         Assert.Equal(TokenType.IntValue, tokens[10].Type);
+        Assert.Equal(TokenType.EOF, tokens[^1].Type);
     }
 
     [Fact]
@@ -386,9 +403,10 @@ public class ScannerTests
         var tokens = scanner.GetTokens();
 
         // Assert
-        Assert.Equal(2, tokens.Count);
+        Assert.Equal(3, tokens.Count);
         Assert.Equal(0, tokens[0].Start);
         Assert.Equal(7, tokens[1].Start);
+        Assert.Equal(TokenType.EOF, tokens[^1].Type);
     }
 
     [Fact]
@@ -402,9 +420,10 @@ public class ScannerTests
         var tokens = scanner.GetTokens();
 
         // Assert
-        Assert.Single(tokens);
+        Assert.Equal(2, tokens.Count);
         Assert.Equal(TokenType.StringValue, tokens[0].Type);
         Assert.Equal("unterminated", tokens[0].Literal);
+        Assert.Equal(TokenType.EOF, tokens[^1].Type);
     }
 
     [Fact]
@@ -418,10 +437,11 @@ public class ScannerTests
         var tokens = scanner.GetTokens();
 
         // Assert
-        Assert.Equal(3, tokens.Count);
+        Assert.Equal(4, tokens.Count);
         Assert.Equal(TokenType.BangEqual, tokens[0].Type);
         Assert.Equal(TokenType.LessThanEqual, tokens[1].Type);
         Assert.Equal(TokenType.GreaterThanEqual, tokens[2].Type);
+        Assert.Equal(TokenType.EOF, tokens[^1].Type);
     }
 
     [Fact]
@@ -435,7 +455,7 @@ public class ScannerTests
         var tokens = scanner.GetTokens();
 
         // Assert
-        Assert.Equal(8, tokens.Count);
+        Assert.Equal(9, tokens.Count);
         Assert.Equal(TokenType.Select, tokens[0].Type);
         Assert.Equal(TokenType.Identifier, tokens[1].Type);
         Assert.Equal(TokenType.AS, tokens[2].Type);
@@ -444,5 +464,6 @@ public class ScannerTests
         Assert.Equal(TokenType.Identifier, tokens[5].Type);
         Assert.Equal(TokenType.AS, tokens[6].Type);
         Assert.Equal(TokenType.Identifier, tokens[7].Type);
+        Assert.Equal(TokenType.EOF, tokens[^1].Type);
     }
 }

--- a/test/SimpleDb.UnitTests/Parsing/ScannerTests.cs
+++ b/test/SimpleDb.UnitTests/Parsing/ScannerTests.cs
@@ -466,4 +466,50 @@ public class ScannerTests
         Assert.Equal(TokenType.Identifier, tokens[7].Type);
         Assert.Equal(TokenType.EOF, tokens[^1].Type);
     }
+
+    [Theory]
+    [InlineData("select id, name, age from users", 9)]
+    public void Scanner_QueryWithMultipleColumns(string query, int token_count)
+    {
+        // Arrange
+        var scanner = new Scanner(query);
+        // Act
+        var tokens = scanner.GetTokens();
+        // Assert
+        Assert.Equal(token_count, tokens.Count);
+        Assert.Equal(TokenType.Select, tokens[0].Type);
+        Assert.Equal(TokenType.Identifier, tokens[1].Type);
+        Assert.Equal(TokenType.Comma, tokens[2].Type);
+        Assert.Equal(TokenType.Identifier, tokens[3].Type);
+        Assert.Equal(TokenType.Comma, tokens[4].Type);
+        Assert.Equal(TokenType.Identifier, tokens[5].Type);
+        Assert.Equal(TokenType.From, tokens[6].Type);
+        Assert.Equal(TokenType.Identifier, tokens[7].Type);
+        Assert.Equal(TokenType.EOF, tokens[^1].Type);
+    }
+
+    [Fact]
+    public void Scanner_QueryWithMultipleColumnsAndAlias()
+    {
+        // Arrange
+        var query = "select id, name as full_name, age from users as u";
+        var scanner = new Scanner(query);
+        // Act
+        var tokens = scanner.GetTokens();
+        // Assert
+        Assert.Equal(13, tokens.Count);
+        Assert.Equal(TokenType.Select, tokens[0].Type);
+        Assert.Equal(TokenType.Identifier, tokens[1].Type);
+        Assert.Equal(TokenType.Comma, tokens[2].Type);
+        Assert.Equal(TokenType.Identifier, tokens[3].Type);
+        Assert.Equal(TokenType.As, tokens[4].Type);
+        Assert.Equal(TokenType.Identifier, tokens[5].Type);
+        Assert.Equal(TokenType.Comma, tokens[6].Type);
+        Assert.Equal(TokenType.Identifier, tokens[7].Type);
+        Assert.Equal(TokenType.From, tokens[8].Type);
+        Assert.Equal(TokenType.Identifier, tokens[9].Type);
+        Assert.Equal(TokenType.As, tokens[10].Type);
+        Assert.Equal(TokenType.Identifier, tokens[11].Type);
+        Assert.Equal(TokenType.EOF, tokens[^1].Type);
+    }
 }

--- a/test/SimpleDb.UnitTests/Parsing/ScannerTests.cs
+++ b/test/SimpleDb.UnitTests/Parsing/ScannerTests.cs
@@ -13,8 +13,8 @@ public class ScannerTests
     [InlineData("DELETE", TokenType.Delete)]
     [InlineData("from", TokenType.From)]
     [InlineData("FROM", TokenType.From)]
-    [InlineData("as", TokenType.AS)]
-    [InlineData("AS", TokenType.AS)]
+    [InlineData("as", TokenType.As)]
+    [InlineData("AS", TokenType.As)]
     [InlineData("and", TokenType.And)]
     [InlineData("AND", TokenType.And)]
     [InlineData("or", TokenType.Or)]
@@ -458,11 +458,11 @@ public class ScannerTests
         Assert.Equal(9, tokens.Count);
         Assert.Equal(TokenType.Select, tokens[0].Type);
         Assert.Equal(TokenType.Identifier, tokens[1].Type);
-        Assert.Equal(TokenType.AS, tokens[2].Type);
+        Assert.Equal(TokenType.As, tokens[2].Type);
         Assert.Equal(TokenType.Identifier, tokens[3].Type);
         Assert.Equal(TokenType.From, tokens[4].Type);
         Assert.Equal(TokenType.Identifier, tokens[5].Type);
-        Assert.Equal(TokenType.AS, tokens[6].Type);
+        Assert.Equal(TokenType.As, tokens[6].Type);
         Assert.Equal(TokenType.Identifier, tokens[7].Type);
         Assert.Equal(TokenType.EOF, tokens[^1].Type);
     }

--- a/test/SimpleDb.UnitTests/Parsing/ScannerTests.cs
+++ b/test/SimpleDb.UnitTests/Parsing/ScannerTests.cs
@@ -512,4 +512,35 @@ public class ScannerTests
         Assert.Equal(TokenType.Identifier, tokens[11].Type);
         Assert.Equal(TokenType.EOF, tokens[^1].Type);
     }
+
+    [Fact]
+    public void Scanner_QueryWithJoinAndMultipleColumns()
+    {
+        // Arrange
+        var query = "select id, name, amount from users as u join orders as o on id = user_id";
+        var scanner = new Scanner(query);
+        // Act
+        var tokens = scanner.GetTokens();
+        // Assert
+        Assert.Equal(19, tokens.Count);
+        Assert.Equal(TokenType.Select, tokens[0].Type);
+        Assert.Equal(TokenType.Identifier, tokens[1].Type);
+        Assert.Equal(TokenType.Comma, tokens[2].Type);
+        Assert.Equal(TokenType.Identifier, tokens[3].Type);
+        Assert.Equal(TokenType.Comma, tokens[4].Type);
+        Assert.Equal(TokenType.Identifier, tokens[5].Type);
+        Assert.Equal(TokenType.From, tokens[6].Type);
+        Assert.Equal(TokenType.Identifier, tokens[7].Type);
+        Assert.Equal(TokenType.As, tokens[8].Type);
+        Assert.Equal(TokenType.Identifier, tokens[9].Type);
+        Assert.Equal(TokenType.Join, tokens[10].Type);
+        Assert.Equal(TokenType.Identifier, tokens[11].Type);
+        Assert.Equal(TokenType.As, tokens[12].Type);
+        Assert.Equal(TokenType.Identifier, tokens[13].Type);
+        Assert.Equal(TokenType.On, tokens[14].Type);
+        Assert.Equal(TokenType.Identifier, tokens[15].Type);
+        Assert.Equal(TokenType.Equal, tokens[16].Type);
+        Assert.Equal(TokenType.Identifier, tokens[17].Type);
+        Assert.Equal(TokenType.EOF, tokens[^1].Type);
+    }
 }

--- a/test/SimpleDb.UnitTests/Parsing/ScannerTests.cs
+++ b/test/SimpleDb.UnitTests/Parsing/ScannerTests.cs
@@ -1,0 +1,448 @@
+using SimpleDb.Parsing;
+
+namespace SimpleDb.UnitTests.Parsing;
+
+public class ScannerTests
+{
+    [Theory]
+    [InlineData("select", TokenType.Select)]
+    [InlineData("SELECT", TokenType.Select)]
+    [InlineData("update", TokenType.Update)]
+    [InlineData("UPDATE", TokenType.Update)]
+    [InlineData("delete", TokenType.Delete)]
+    [InlineData("DELETE", TokenType.Delete)]
+    [InlineData("from", TokenType.From)]
+    [InlineData("FROM", TokenType.From)]
+    [InlineData("as", TokenType.AS)]
+    [InlineData("AS", TokenType.AS)]
+    [InlineData("and", TokenType.And)]
+    [InlineData("AND", TokenType.And)]
+    [InlineData("or", TokenType.Or)]
+    [InlineData("OR", TokenType.Or)]
+    public void Scanner_Recognizes_Keywords_CaseInsensitive(string keyword, TokenType expectedType)
+    {
+        // Arrange
+        var scanner = new Scanner(keyword);
+
+        // Act
+        var tokens = scanner.GetTokens();
+
+        // Assert
+        Assert.Single(tokens);
+        Assert.Equal(expectedType, tokens[0].Type);
+        Assert.Equal(keyword, tokens[0].Lexeme);
+        Assert.Empty(scanner.SyntaxErrors);
+    }
+
+    [Theory]
+    [InlineData("myTable", "myTable")]
+    [InlineData("column1", "column1")]
+    [InlineData("Table123", "Table123")]
+    [InlineData("_invalidStart", "_invalidStart")] // Should trigger error
+    public void Scanner_Recognizes_Identifiers(string identifier, string expectedLexeme)
+    {
+        // Arrange
+        var scanner = new Scanner(identifier);
+
+        // Act
+        var tokens = scanner.GetTokens();
+
+        // Assert
+        if (identifier.StartsWith('_'))
+        {
+            Assert.NotEmpty(scanner.SyntaxErrors);
+        }
+        else
+        {
+            Assert.Single(tokens);
+            Assert.Equal(TokenType.Identifier, tokens[0].Type);
+            Assert.Equal(expectedLexeme, tokens[0].Lexeme);
+            Assert.Equal(expectedLexeme, tokens[0].Literal);
+        }
+    }
+
+    [Theory]
+    [InlineData("0", 0)]
+    [InlineData("123", 123)]
+    [InlineData("456789", 456789)]
+    [InlineData("2147483647", int.MaxValue)]
+    public void Scanner_Recognizes_IntegerValues(string number, int expectedValue)
+    {
+        // Arrange
+        var scanner = new Scanner(number);
+
+        // Act
+        var tokens = scanner.GetTokens();
+
+        // Assert
+        Assert.Single(tokens);
+        Assert.Equal(TokenType.IntValue, tokens[0].Type);
+        Assert.Equal(expectedValue, tokens[0].Literal);
+    }
+
+    [Theory]
+    [InlineData("'hello'", "hello")]
+    [InlineData("'world'", "world")]
+    [InlineData("''", "")]
+    [InlineData("'it''s escaped'", "it's escaped")]
+    [InlineData("'double''quote''test'", "double'quote'test")]
+    public void Scanner_Recognizes_StringValues(string input, string expectedValue)
+    {
+        // Arrange
+        var scanner = new Scanner(input);
+
+        // Act
+        var tokens = scanner.GetTokens();
+
+        // Assert
+        Assert.Single(tokens);
+        Assert.Equal(TokenType.StringValue, tokens[0].Type);
+        Assert.Equal(expectedValue, tokens[0].Literal);
+    }
+
+    [Theory]
+    [InlineData("(", TokenType.LeftParen)]
+    [InlineData(")", TokenType.RightParen)]
+    [InlineData("+", TokenType.Plus)]
+    [InlineData("-", TokenType.Minus)]
+    [InlineData("*", TokenType.Star)]
+    [InlineData("/", TokenType.ForwardSlash)]
+    [InlineData("%", TokenType.Percent)]
+    [InlineData("!", TokenType.Bang)]
+    [InlineData("=", TokenType.Equal)]
+    [InlineData("<", TokenType.LessThan)]
+    [InlineData(">", TokenType.GreaterThan)]
+    public void Scanner_Recognizes_SingleCharacterOperators(string op, TokenType expectedType)
+    {
+        // Arrange
+        var scanner = new Scanner(op);
+
+        // Act
+        var tokens = scanner.GetTokens();
+
+        // Assert
+        Assert.Single(tokens);
+        Assert.Equal(expectedType, tokens[0].Type);
+        Assert.Equal(op, tokens[0].Lexeme);
+    }
+
+    [Theory]
+    [InlineData("!=", TokenType.BangEqual)]
+    [InlineData("<=", TokenType.LessThanEqual)]
+    [InlineData(">=", TokenType.GreaterThanEqual)]
+    public void Scanner_Recognizes_TwoCharacterOperators(string op, TokenType expectedType)
+    {
+        // Arrange
+        var scanner = new Scanner(op);
+
+        // Act
+        var tokens = scanner.GetTokens();
+
+        // Assert
+        Assert.Single(tokens);
+        Assert.Equal(expectedType, tokens[0].Type);
+        Assert.Equal(op, tokens[0].Lexeme);
+    }
+
+    [Fact]
+    public void Scanner_Tokenizes_SimpleSelectQuery()
+    {
+        // Arrange
+        var query = "select id from users";
+        var scanner = new Scanner(query);
+
+        // Act
+        var tokens = scanner.GetTokens();
+
+        // Assert
+        Assert.Equal(4, tokens.Count);
+        Assert.Equal(TokenType.Select, tokens[0].Type);
+        Assert.Equal(TokenType.Identifier, tokens[1].Type);
+        Assert.Equal("id", tokens[1].Literal);
+        Assert.Equal(TokenType.From, tokens[2].Type);
+        Assert.Equal(TokenType.Identifier, tokens[3].Type);
+        Assert.Equal("users", tokens[3].Literal);
+        Assert.Empty(scanner.SyntaxErrors);
+    }
+
+    [Fact]
+    public void Scanner_Tokenizes_ComplexExpression()
+    {
+        // Arrange
+        var query = "select id + 10 * 2 from users";
+        var scanner = new Scanner(query);
+
+        // Act
+        var tokens = scanner.GetTokens();
+
+        // Assert
+        Assert.Equal(8, tokens.Count);
+        Assert.Equal(TokenType.Select, tokens[0].Type);
+        Assert.Equal(TokenType.Identifier, tokens[1].Type);
+        Assert.Equal(TokenType.Plus, tokens[2].Type);
+        Assert.Equal(TokenType.IntValue, tokens[3].Type);
+        Assert.Equal(10, tokens[3].Literal);
+        Assert.Equal(TokenType.Star, tokens[4].Type);
+        Assert.Equal(TokenType.IntValue, tokens[5].Type);
+        Assert.Equal(2, tokens[5].Literal);
+        Assert.Equal(TokenType.From, tokens[6].Type);
+        Assert.Equal(TokenType.Identifier, tokens[7].Type);
+    }
+
+    [Fact]
+    public void Scanner_Tokenizes_QueryWithParentheses()
+    {
+        // Arrange
+        var query = "select (id + 10) from users";
+        var scanner = new Scanner(query);
+
+        // Act
+        var tokens = scanner.GetTokens();
+
+        // Assert
+        Assert.Equal(8, tokens.Count);
+        Assert.Equal(TokenType.Select, tokens[0].Type);
+        Assert.Equal(TokenType.LeftParen, tokens[1].Type);
+        Assert.Equal(TokenType.Identifier, tokens[2].Type);
+        Assert.Equal(TokenType.Plus, tokens[3].Type);
+        Assert.Equal(TokenType.IntValue, tokens[4].Type);
+        Assert.Equal(TokenType.RightParen, tokens[5].Type);
+        Assert.Equal(TokenType.From, tokens[6].Type);
+        Assert.Equal(TokenType.Identifier, tokens[7].Type);
+    }
+
+    [Fact]
+    public void Scanner_Tokenizes_QueryWithStringLiterals()
+    {
+        // Arrange
+        var query = "select name from users";
+        var scanner = new Scanner(query);
+
+        // Act
+        var tokens = scanner.GetTokens();
+
+        // Assert
+        Assert.Equal(4, tokens.Count);
+        Assert.Equal(TokenType.Select, tokens[0].Type);
+        Assert.Equal(TokenType.Identifier, tokens[1].Type);
+        Assert.Equal(TokenType.From, tokens[2].Type);
+        Assert.Equal(TokenType.Identifier, tokens[3].Type);
+    }
+
+    [Fact]
+    public void Scanner_Tokenizes_QueryWithComparisonOperators()
+    {
+        // Arrange
+        var query = "id = 10 and age >= 18 or status != 'active'";
+        var scanner = new Scanner(query);
+
+        // Act
+        var tokens = scanner.GetTokens();
+
+        // Assert
+        Assert.Equal(11, tokens.Count);
+        Assert.Equal(TokenType.Identifier, tokens[0].Type);
+        Assert.Equal(TokenType.Equal, tokens[1].Type);
+        Assert.Equal(TokenType.IntValue, tokens[2].Type);
+        Assert.Equal(TokenType.And, tokens[3].Type);
+        Assert.Equal(TokenType.Identifier, tokens[4].Type);
+        Assert.Equal(TokenType.GreaterThanEqual, tokens[5].Type);
+        Assert.Equal(TokenType.IntValue, tokens[6].Type);
+        Assert.Equal(TokenType.Or, tokens[7].Type);
+        Assert.Equal(TokenType.Identifier, tokens[8].Type);
+        Assert.Equal(TokenType.BangEqual, tokens[9].Type);
+        Assert.Equal(TokenType.StringValue, tokens[10].Type);
+        Assert.Equal("active", tokens[10].Literal);
+    }
+
+    [Fact]
+    public void Scanner_IgnoresWhitespace()
+    {
+        // Arrange
+        var query = "  select   id  \t from  \r users  ";
+        var scanner = new Scanner(query);
+
+        // Act
+        var tokens = scanner.GetTokens();
+
+        // Assert
+        Assert.Equal(4, tokens.Count);
+        Assert.Equal(TokenType.Select, tokens[0].Type);
+        Assert.Equal(TokenType.Identifier, tokens[1].Type);
+        Assert.Equal(TokenType.From, tokens[2].Type);
+        Assert.Equal(TokenType.Identifier, tokens[3].Type);
+    }
+
+    [Fact]
+    public void Scanner_ReportsErrorForUnexpectedCharacter()
+    {
+        // Arrange
+        var query = "select @ from users";
+        var scanner = new Scanner(query);
+
+        // Act
+        var tokens = scanner.GetTokens();
+
+        // Assert
+        Assert.Single(scanner.SyntaxErrors);
+        Assert.Contains("Unexpected char: '@'", scanner.SyntaxErrors[0].Message);
+    }
+
+    [Fact]
+    public void Scanner_HandlesEmptyInput()
+    {
+        // Arrange
+        var scanner = new Scanner("");
+
+        // Act
+        var tokens = scanner.GetTokens();
+
+        // Assert
+        Assert.Empty(tokens);
+        Assert.Empty(scanner.SyntaxErrors);
+    }
+
+    [Fact]
+    public void Scanner_HandlesOnlyWhitespace()
+    {
+        // Arrange
+        var scanner = new Scanner("   \t  \r  ");
+
+        // Act
+        var tokens = scanner.GetTokens();
+
+        // Assert
+        Assert.Empty(tokens);
+        Assert.Empty(scanner.SyntaxErrors);
+    }
+
+    [Fact]
+    public void Scanner_TokenizesUpdateQuery()
+    {
+        // Arrange
+        var query = "update users";
+        var scanner = new Scanner(query);
+
+        // Act
+        var tokens = scanner.GetTokens();
+
+        // Assert
+        Assert.Equal(2, tokens.Count);
+        Assert.Equal(TokenType.Update, tokens[0].Type);
+        Assert.Equal(TokenType.Identifier, tokens[1].Type);
+        Assert.Equal("users", tokens[1].Literal);
+    }
+
+    [Fact]
+    public void Scanner_TokenizesDeleteQuery()
+    {
+        // Arrange
+        var query = "delete from users";
+        var scanner = new Scanner(query);
+
+        // Act
+        var tokens = scanner.GetTokens();
+
+        // Assert
+        Assert.Equal(3, tokens.Count);
+        Assert.Equal(TokenType.Delete, tokens[0].Type);
+        Assert.Equal(TokenType.From, tokens[1].Type);
+        Assert.Equal(TokenType.Identifier, tokens[2].Type);
+    }
+
+    [Fact]
+    public void Scanner_TokenizesAllArithmeticOperators()
+    {
+        // Arrange
+        var query = "5 + 3 - 2 * 10 / 2 % 3";
+        var scanner = new Scanner(query);
+
+        // Act
+        var tokens = scanner.GetTokens();
+
+        // Assert
+        Assert.Equal(11, tokens.Count);
+        Assert.Equal(TokenType.IntValue, tokens[0].Type);
+        Assert.Equal(TokenType.Plus, tokens[1].Type);
+        Assert.Equal(TokenType.IntValue, tokens[2].Type);
+        Assert.Equal(TokenType.Minus, tokens[3].Type);
+        Assert.Equal(TokenType.IntValue, tokens[4].Type);
+        Assert.Equal(TokenType.Star, tokens[5].Type);
+        Assert.Equal(TokenType.IntValue, tokens[6].Type);
+        Assert.Equal(TokenType.ForwardSlash, tokens[7].Type);
+        Assert.Equal(TokenType.IntValue, tokens[8].Type);
+        Assert.Equal(TokenType.Percent, tokens[9].Type);
+        Assert.Equal(TokenType.IntValue, tokens[10].Type);
+    }
+
+    [Fact]
+    public void Scanner_SetsCorrectStartPositionForTokens()
+    {
+        // Arrange
+        var query = "select id";
+        var scanner = new Scanner(query);
+
+        // Act
+        var tokens = scanner.GetTokens();
+
+        // Assert
+        Assert.Equal(2, tokens.Count);
+        Assert.Equal(0, tokens[0].Start);
+        Assert.Equal(7, tokens[1].Start);
+    }
+
+    [Fact]
+    public void Scanner_HandlesUnterminatedString()
+    {
+        // Arrange
+        var query = "'unterminated";
+        var scanner = new Scanner(query);
+
+        // Act
+        var tokens = scanner.GetTokens();
+
+        // Assert
+        Assert.Single(tokens);
+        Assert.Equal(TokenType.StringValue, tokens[0].Type);
+        Assert.Equal("unterminated", tokens[0].Literal);
+    }
+
+    [Fact]
+    public void Scanner_HandlesConsecutiveOperators()
+    {
+        // Arrange
+        var query = "!= <= >=";
+        var scanner = new Scanner(query);
+
+        // Act
+        var tokens = scanner.GetTokens();
+
+        // Assert
+        Assert.Equal(3, tokens.Count);
+        Assert.Equal(TokenType.BangEqual, tokens[0].Type);
+        Assert.Equal(TokenType.LessThanEqual, tokens[1].Type);
+        Assert.Equal(TokenType.GreaterThanEqual, tokens[2].Type);
+    }
+
+    [Fact]
+    public void Scanner_HandlesAliasWithAS()
+    {
+        // Arrange
+        var query = "select id as userId from users as u";
+        var scanner = new Scanner(query);
+
+        // Act
+        var tokens = scanner.GetTokens();
+
+        // Assert
+        Assert.Equal(8, tokens.Count);
+        Assert.Equal(TokenType.Select, tokens[0].Type);
+        Assert.Equal(TokenType.Identifier, tokens[1].Type);
+        Assert.Equal(TokenType.AS, tokens[2].Type);
+        Assert.Equal(TokenType.Identifier, tokens[3].Type);
+        Assert.Equal(TokenType.From, tokens[4].Type);
+        Assert.Equal(TokenType.Identifier, tokens[5].Type);
+        Assert.Equal(TokenType.AS, tokens[6].Type);
+        Assert.Equal(TokenType.Identifier, tokens[7].Type);
+    }
+}


### PR DESCRIPTION
Add support for parsing sql statements. The parser supports statements like below:

1. select * from table
2. select a, b from c
3. select a as e, b as k from c as d
4. select a, b from (select e as a, max(i, j) as b from mytable) d